### PR TITLE
Move SOLR from Bitnami to address M1 chip issue

### DIFF
--- a/.env
+++ b/.env
@@ -22,13 +22,16 @@ SEED_EXTRA_DATA=true
 HYRAX_ACTIVE_JOB_QUEUE=sidekiq
 HYKU_BULKRAX_ENABLED=true
 HYRAX_FITS_PATH=/app/fits/fits.sh
-SOLR_ADMIN_PASSWORD=admin
-SOLR_ADMIN_USER=admin
-SOLR_COLLECTION_NAME=hydra-development
+SOLR_ADMIN_PASSWORD=SolrRocks
+SOLR_ADMIN_USER=solr
+SOLR_COLLECTION=hydra-development
+SOLR_COLLECTION_NAME="${SOLR_COLLECTION}"
 SOLR_CONFIGSET_NAME=hyku
+SOLR_ENABLE_AUTHENTICATION=yes
 SOLR_HOST=solr
 SOLR_PORT=8983
-SOLR_URL=http://admin:admin@solr:8983/solr/
+SOLR_URL="http://${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASSWORD}@${SOLR_HOST}:${SOLR_PORT}/solr/"
+ZK_HOST=zoo:2181
 
 # Comment out these 5 for single tenancy / Uncomment for multi
 HYKU_ADMIN_HOST=admin.bl.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,40 +12,41 @@ x-app: &app
     - .env
   # NOTE: all common env variables moved to .env
   volumes:
-    - uploads:/app/samvera/hyrax-webapp/public/uploads
-    - assets:/app/samvera/hyrax-webapp/public/assets
-    - cache:/app/samvera/hyrax-webapp/tmp/cache
+    - uploads:/app/samvera/hyrax-webapp/public/uploads:cached
+    - assets:/app/samvera/hyrax-webapp/public/assets:cached
+    - cache:/app/samvera/hyrax-webapp/tmp/cache:cached
     - .:/app/samvera/hyrax-webapp
   networks:
     internal:
 
 volumes:
-  fcrepo:
-  solr:
-  db:
-  redis:
-  zk:
-  uploads:
   assets:
   cache:
+  db:
+  fcrepo:
+  redis:
+  solr:
+  uploads:
+  zk:
+  zoo:
 
 networks:
   internal:
 
 services:
   zoo:
-    image: bitnami/zookeeper:3.6
+    image: zookeeper:3.6.2
+    ports:
+      - 2181:2181
+      - 7001:7000
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-      - ZOO_4LW_COMMANDS_WHITELIST=mntr, srvr, ruok
+      - ZOO_MY_ID=1
+      - ZOO_4LW_COMMANDS_WHITELIST=mntr,srvr,ruok,conf
       - ZOO_SERVER_ID=1
-      - ZOO_SERVERS=zoo:2888:3888
-    expose:
-      - 2181
-      - 2888
-      - 3888
+      - ZOO_SERVERS=server.1=zoo:2888:3888;2181
     volumes:
-      - zk:/bitnami/zookeeper
+      - zoo:/data
+      - zk:/datalog
     networks:
       internal:
     healthcheck:
@@ -54,34 +55,36 @@ services:
       timeout: "8s"
 
   solr:
-    image: bitnami/solr:8
+    image: hyku/solr:8
+    build:
+      context: solr
+      dockerfile: Dockerfile
+    env_file:
+      - .env
     environment:
       - OOM=script
-      - SOLR_ADMIN_USERNAME=admin
-      - SOLR_ADMIN_PASSWORD=admin
-      - SOLR_COLLECTION=hydra-development
-      - SOLR_CLOUD_BOOTSTRAP=yes
-      - SOLR_ENABLE_CLOUD_MODE=yes
-      - SOLR_ENABLE_AUTHENTICATION=yes
-      - SOLR_PORT_NUMBER=8983
-      - SOLR_ZK_HOSTS=zoo
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.bl.test
     depends_on:
       zoo:
         condition: service_healthy
+    user: root
+    command: bash -c "
+      chown -R 8983:8983 /var/solr
+      && ./bin/solr zk cp file:/var/security.json zk:/security.json
+      && runuser -u solr -- solr-foreground"
     expose:
       - 8983
     volumes:
-      - solr:/bitnami
+      - solr:/var/solr
     networks:
       internal:
     healthcheck:
-      test: curl -sf http://$$SOLR_ADMIN_USERNAME:$$SOLR_ADMIN_PASSWORD@localhost:8983/solr/$$SOLR_COLLECTION/admin/ping?wt=json\&distrib=true || exit 1
-      start_period: 30s
-      interval: 20s
+      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@solr:8983/solr/admin/cores?action=STATUS || exit 1
+      start_period: 3s
+      interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 6
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,0 +1,6 @@
+FROM solr:8.3
+ENV SOLR_USER="solr" \
+    SOLR_GROUP="solr"
+USER root
+COPY --chown=solr:solr security.json /var/security.json
+USER $SOLR_USER

--- a/solr/security.json
+++ b/solr/security.json
@@ -1,0 +1,15 @@
+{
+  "authentication":{
+      "blockUnknown": true,
+      "class":"solr.BasicAuthPlugin",
+      "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="},
+      "realm":"My Solr users",
+      "forwardCredentials": false
+  },
+  "authorization":{
+      "class":"solr.RuleBasedAuthorizationPlugin",
+      "permissions":[{"name":"security-edit",
+                      "role":"admin"}],
+      "user-role":{"solr":"admin"}
+  }
+}


### PR DESCRIPTION
These changes are cribbed from [Adventist's b53bbc6b commit][1].

Prior to this commit, when I ran `sc up` the script exited with the following message:

> container for service "solr" is unhealthy

With this commit, when I run `sc up` the script successfully boots up the stack and I can go to `http://admin.bl.test`.

One caveat is that there is also a `docker-compose.production.yml` file.  I have not cross-checked that file with the `docker-compose.yml` changes; this is not a space I am yet prepared to explore (nor do I have adequate knowledge to say whether or not this needs changing and what to change).

Relates to:

- #201

[1]: https://github.com/scientist-softserv/adventist-dl/commit/b53bbc6b3b827423f8b7486f60b544ad7b593af5
