### PR TITLE
Conditionally render BrowseEverything based on config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,13 @@ module ApplicationHelper
       full_url.host.split('.').first
     end
   end
+
+  def render_browse_everything_ui_upload_widget?
+    return false unless Hyrax.config.browse_everything?
+    return false unless defined?(BrowseEverything)
+    return true if params[:cloud].present?
+
+    # True if we have non- "file_system" BrowseEverything providers
+    BrowseEverything.config&.keys&.detect { |provider| provider.to_s != "file_system" }
+  end
 end

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -4,7 +4,7 @@
    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
    <!-- The table listing the files available for upload/download -->
    <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-   <% if Hyrax.config.browse_everything? %>
+   <% if render_browse_everything_ui_upload_widget? %>
      <%= t('hyrax.base.form_files.local_upload_browse_everything_html', contact_href: link_to(t("hyrax.upload.alert.contact_href_text"), hyrax.contact_form_index_path)) %>
    <% else %>
      <%= t('hyrax.base.form_files.local_upload_html') %>
@@ -25,7 +25,7 @@
                <span>Add folder...</span>
                <input type="file" name="files[]" multiple directory webkitdirectory />
            </span>
-           <% if Hyrax.config.browse_everything? && params['cloud'].present? %>
+           <% if render_browse_everything_ui_upload_widget? %>
              <%= button_tag(type: 'button', class: 'btn btn-success', id: "browse-e-btn") do %>
                <span class="glyphicon glyphicon-plus"></span>
                <%= t('hyrax.upload.browse_everything.browse_files_button') %>


### PR DESCRIPTION
Prior to this commit, the only time we would render the BrowseEverything link was when someone requested the page with the `params[:cloud]` parameter.

However, as we look to configure BrowseEverything to use remotes, that conditional would be a stumbling block.

With this commit, we now inspect the Hyrax and BrowseEverything configuration to see if we should render the widget.  As a courtesy, I have preserved the `params[:cloud]` as a short-cut.  In fact, that courtesy makes it far easier to test if the buttons are present.

/Note:/ this does not resolve of whether or not it works to select a file via browse everything and then "process" that file to attach to a work.

Related to:

- #190
