### PR TITLE
Bumping Bulkrax to 3.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ end
 
 # Bulkrax
 group :bulkrax do
-  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', tag: 'v3.3.0'
+  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', tag: 'v3.5.1'
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: beb3e215ce7bd2a2486ab9de572e74e5eee54ee1
-  tag: v3.3.0
+  revision: 0a644637260378ac25fd9e3d4b2e68addb2b3ade
+  tag: v3.5.1
   specs:
-    bulkrax (3.3.0)
+    bulkrax (3.5.1)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)
@@ -35,6 +35,7 @@ GIT
       rack (>= 2.0.6)
       rails (>= 5.1.6)
       rdf (>= 2.0.2, < 4.0)
+      rubyzip
       simple_form
 
 GIT


### PR DESCRIPTION
This is the last minor version release before Bulkrax 4.0.  It should be
safe to apply as Bulkrax adhears to semantic versioning.

Updated in response to, and perhaps helps resolve the following:

- #132
- #118
