### PR TITLE
Collaborative doctoral student has been added as a third category to …

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -17,6 +17,7 @@ module Bulkrax::HasLocalProcessing
     acceptable_values = {
       'researchassociate': 'Research associate',
       'staffmember': 'Staff member'
+      'doctoralcollaborativestudent': 'Doctoral collaborative student'
     }
 
     # remove the invalid keys in the array below and use the `<object>_institional_relationship` key only

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -16,7 +16,7 @@ module Bulkrax::HasLocalProcessing
   def set_institutional_relationships
     acceptable_values = {
       'researchassociate': 'Research associate',
-      'staffmember': 'Staff member'
+      'staffmember': 'Staff member',
       'doctoralcollaborativestudent': 'Doctoral collaborative student'
     }
 

--- a/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
@@ -124,7 +124,7 @@
           Contributor institutional relationship
         </label>
         <%= select_tag  "#{template}[contributor_group][][contributor_institutional_relationship]",
-                        options_from_collection_for_select(['Staff member', 'Research associate'], :to_s, :to_s, hash.dig("contributor_institutional_relationship")),
+                        options_from_collection_for_select(['Staff member', 'Research associate', 'Collaborative doctoral student'], :to_s, :to_s, hash.dig("contributor_institutional_relationship")),
                         multiple: true,
                         class: "form-control"
         %>

--- a/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
@@ -140,7 +140,7 @@
           Creator institutional relationship
         </label>
         <%= select_tag  "#{template}[creator_group][][creator_institutional_relationship]",
-                        options_from_collection_for_select( ['Staff member', 'Research associate'], :to_s, :to_s, hash.dig("creator_institutional_relationship")),
+                        options_from_collection_for_select( ['Staff member', 'Research associate', 'Collaborative doctoral student'], :to_s, :to_s, hash.dig("creator_institutional_relationship")),
                         multiple: true,
                         class: "form-control"
         %>

--- a/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
@@ -77,7 +77,7 @@
           Editor institutional relationship
         </label>
         <%= select_tag  "#{template}[editor_group][][editor_institutional_relationship]",
-                        options_from_collection_for_select( ['Staff member', 'Research associate'], :to_s, :to_s, hash.dig("editor_institutional_relationship")),
+                        options_from_collection_for_select( ['Staff member', 'Research associate', 'Collaborative doctoral student'], :to_s, :to_s, hash.dig("editor_institutional_relationship")),
                         multiple: true,
                         class: "form-control"
         %>


### PR DESCRIPTION
The creator, contributor, and editor institutional relationships have been edited to add the 'Collaborative doctoral student' as a third category to the relationship.

Fixes #120 

Changes proposed in this pull request:
'Collaborative doctoral student' has been added as a third category to:
* creator institutional relationship
* contributor institutional relationship
* editor institutional relationship

Creator
![image](https://user-images.githubusercontent.com/95306716/205995448-2f6c4274-1998-4253-8236-06b27d7d353b.png)
Contributor
![image](https://user-images.githubusercontent.com/95306716/205993111-3d24ca29-d269-425d-bbb8-4f9fde409431.png)
Editor
![image](https://user-images.githubusercontent.com/95306716/206006745-94d6d465-5288-4d47-bbda-853ae74c1ed6.png)
