### PR TITLE
updates actions to arm-wrestle branch

### DIFF
--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -37,11 +37,11 @@ jobs:
       target: hyku-worker
   test:
     needs: build-web
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@arm-wrestle
     with:
       worker: true
   lint:
     needs: build-web
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@arm-wrestle
     with:
       worker: true

--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -38,11 +38,6 @@ jobs:
   test:
     needs: build-web
     uses: scientist-softserv/build-lint-test-action/.github/workflows/test.yaml@chmod-backport
-    with:
-      worker: true
   lint:
     needs: build-web
     uses: scientist-softserv/build-lint-test-action/.github/workflows/lint.yaml@chmod-backport
-    with:
-      worker: true
-

--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -37,11 +37,11 @@ jobs:
       target: hyku-worker
   test:
     needs: build-web
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@arm-wrestle
+    uses: scientist-softserv/build-lint-test-action/.github/workflows/test.yaml@chmod-backport
     with:
       worker: true
   lint:
     needs: build-web
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@arm-wrestle
+    uses: scientist-softserv/build-lint-test-action/.github/workflows/lint.yaml@chmod-backport
     with:
       worker: true

--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -45,3 +45,4 @@ jobs:
     uses: scientist-softserv/build-lint-test-action/.github/workflows/lint.yaml@chmod-backport
     with:
       worker: true
+

--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -1,12 +1,47 @@
-name: "Build Test Lint"
-on: 
+name: "Build Lint Test"
+on:
   push:
     branches:
       - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
-  call-workflow:
-    uses: scientist-softserv/build-lint-test-action/.github/workflows/build-test-lint.yaml@v0.0.1
+  build-web:
+    uses: scientist-softserv/actions/.github/workflows/build-web.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      target: hyku-base
+  build-web-arm64:
+    uses: scientist-softserv/actions/.github/workflows/build-web-arm64.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      target: hyku-base
+  build-worker:
+    uses: scientist-softserv/actions/.github/workflows/build-worker.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      target: hyku-worker
+  build-worker-arm64:
+    uses: scientist-softserv/actions/.github/workflows/build-worker-arm64.yaml@arm-wrestle
+    secrets: inherit
+    with:
+      target: hyku-worker
+  test:
+    needs: build-web
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
+    with:
+      worker: true
+  lint:
+    needs: build-web
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
+    with:
+      worker: true


### PR DESCRIPTION
Ref ticket: https://github.com/scientist-softserv/dev-ops/issues/498

Updates to use the arm-wrestle branch for actions:
- separates the web/worker/solr builds
- and separates the platform builds arm64/amd64
- which allows our tests, lint, and deploys to happen before the arm64 image is even built and pushed to the registry since the lint/tests only depend on the amd64 build (which is roughly 15 minutes), and the deploy depends on the sha that is pushed to the registry form the amd64 build and push.

https://github.com/scientist-softserv/actions/pull/18