### PR TITLE
Favoring gem for graph indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,3 +149,4 @@ gem "sentry-raven"
 gem 'sidekiq'
 gem 'tether-rails'
 gem 'validate_url'
+gem 'hyrax-v2_graph_indexer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,6 +587,9 @@ GEM
       signet
       solrizer (>= 3.4, < 5)
       tinymce-rails (~> 4.1)
+    hyrax-v2_graph_indexer (0.1.0)
+      hyrax (~> 2.9)
+      railties
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
@@ -1233,6 +1236,7 @@ DEPENDENCIES
   httparty
   hyrax (~> 2.9, >= 2.9.1)
   hyrax-doi!
+  hyrax-v2_graph_indexer
   i18n-debug
   i18n-tasks
   irus_analytics!


### PR DESCRIPTION
This afternoon, I spent time extracting the deleted `lib/hyrax/solr_native_nesting_indexer_decorator.rb` into the [Hyrax::V2GraphIndexer][1] gem.

As documented in that gem's [initial commit][2]:

> To verify, I:
>
> - Commented out the code changes made in Adventist
> - Added this gem to the Gemfile
> - Testing the adding of collections in the Adventist code-base
>
> I have the same behavior.  So things are working as desired.

[1]: https://github.com/scientist-softserv/hyrax-v2_graph_indexer
[2]: https://github.com/scientist-softserv/hyrax-v2_graph_indexer/commit/1900b6bd929f86abaea55302f3403c0b27d2e14e

#213 