### PR TITLE
make-test-lint-depend-on-worker-too

### DIFF
--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -36,8 +36,8 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/build-lint-test-action/.github/workflows/test.yaml@chmod-backport
   lint:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/build-lint-test-action/.github/workflows/lint.yaml@chmod-backport


### PR DESCRIPTION
Tests and lint would intermittently fail on this branch of the actions because they were only dependent on the web pod, this updates it to be dependent on the worker so it wait for both to be complete before starting the tests or linting jobs since they need the worker too.