### PR TITLE
Updated footer link to sotware services

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -42,7 +42,7 @@
     <div class="navbar-right">
       <div class="navbar-text text-right footer-link">
         Managed by the <a href="https://www.bl.uk/">British Library</a>
-        <br/>Provided by <a href="https://www.notch8.com/">Notch8</a> & <a href="https://cosector.com/">CoSector</a>
+        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> & <a href="https://cosector.com/">CoSector</a>
       </div>
     </div>
   </div>

--- a/app/views/themes/bl_shared_home/shared/_footer.html.erb
+++ b/app/views/themes/bl_shared_home/shared/_footer.html.erb
@@ -23,7 +23,7 @@
     <div class="navbar-right">
       <div class="navbar-text text-right footer-link">
         Managed by the <a href="https://www.bl.uk/">British Library</a>
-        <br/>Provided by <a href="https://www.notch8.com/">Notch8</a> & <a href="https://cosector.com/">CoSector</a>
+        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> & <a href="https://cosector.com/">CoSector</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Before this commit:
The footer referenced Notch8

This commit:
Updates the footer Software Services from Notch8.

![image](https://user-images.githubusercontent.com/95306716/207703444-7479d32d-cceb-41f6-8a9c-39fccd47ed0b.png)