### PR TITLE
Switching to POST requests for SOLR

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -42,6 +42,13 @@ class CatalogController < ApplicationController
     config.view.gallery.partials = %i[index_header index]
     config.view.slideshow.partials = [:index]
 
+    # See https://github.com/samvera/hyrax/pull/4728 and
+    #     https://samvera.slack.com/archives/CA8ANGLEL/p1670511790348669
+    #
+    # Without this parameter, we can easily enter a situation where the Solr query is too long for a
+    # GET request.  Switching to :post avoids that problem.
+    config.http_method :post
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: "search",


### PR DESCRIPTION
Reviewing the logs I found:

```shell
ERROR -- : [c94e8538d4e27e31ce8995e3cf6af992] RSolr::Error::Http - 400 Bad Request
Error: {
  "responseHeader":{
    "zkConnected":true,
    "status":400,
    "QTime":0,
    "params":{
      "facet.field":["human_readable_type_sim",
        "resource_type_label_ssim",
        "creator_search_sim",
        "keyword_sim",
        "subject_sim",
```

The following line showed a string that was 2284 characters long and ended in `f.member_of_collection_ids_ssim.facet.matches=%5E%24`; those trailing characters decoded `^$` which could be a complete end of a query (e.g. an empty string regexp match).

Related to:

- samvera/hyrax#4728
- scientist-softserv/britishlibrary#222

@samvera/hyku-code-reviewers
