### PR TITLE
Added logo to shared theme

### DIFF
--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="container homepage-container">
   <div class= "row">
-    <div class="col-sm-6 pt-40 homepage-left">
+    <div class="col-sm-6 pt-20 homepage-left">
       <div class= "flex">
          <%= image_tag("bannerlogo.png", class: "tenant-logo banner-logo", alt: "Shared Research Repository") %>
         <div>

--- a/app/views/themes/bl_shared_home/splash/_index.html.erb
+++ b/app/views/themes/bl_shared_home/splash/_index.html.erb
@@ -1,9 +1,14 @@
 <%# This partial is the equivalent to what used to be the splash page for BL: splash/index.html.erb %>
 <div class="container homepage-container">
   <div class= "row">
-    <div class="col-sm-6 pt-40 homepage-left">
-      <h1>Shared Research Repository</h1>
-      <h3 class="splash-page">for cultural and heritage organisations</h3>
+    <div class="col-sm-6 pt-20 homepage-left">
+      <div class= "flex">
+         <%= image_tag("bannerlogo.png", class: "tenant-logo banner-logo", alt: "Shared Research Repository") %>
+        <div>
+          <h2>Shared Research Repository</h2>
+          <h3 class="splash-page">for cultural and heritage organisations</h3>
+        </div>
+      </div>
       <h4 class="pt-40 splash-page">
         Welcome to our shared repository where you’ll find research produced by staff of the British Library and our current partner organisations: the British Museum, MOLA (Museum of London Archaeology), National Museums Scotland and Royal Botanic Gardens, Kew.<br/><br/>
         Visit one repository at a time, or use the search box to search and explore publications, reports, datasets and papers from across our combined content.


### PR DESCRIPTION
Before this PR, the logo would not show on the landing page before signing in.
![Screenshot 2022-12-20 at 12 57 10 PM](https://user-images.githubusercontent.com/95306716/208764917-45e89814-d95c-474d-ade9-6747e2b99a72.png)


Changes proposed in this pull request:
The shared theme was updated with the banner logo image. 
* The logo shows on the page prior to login as well as when logged in.

admin.bl.test - Not signed in
![Screenshot 2022-12-20 at 12 06 08 PM](https://user-images.githubusercontent.com/95306716/208764386-796743fe-ddc4-458c-82cf-83362160573a.png)
admin.bl.test -Signed in as admin
![Screenshot 2022-12-20 at 12 06 56 PM](https://user-images.githubusercontent.com/95306716/208764517-9602c19d-6895-437d-aba4-2be01f4fa442.png)