### PR TITLE
Removed css to fix logos

### DIFF
--- a/app/assets/stylesheets/bl-overrides.scss
+++ b/app/assets/stylesheets/bl-overrides.scss
@@ -1335,14 +1335,6 @@ body.public-facing.bl-public-facing {
     color: $mediumgrey2 !important;
   }
 
-  li.attribute.creator,
-  li.attribute.contributor,
-  li.attribute.editor {
-    span a img.img-responsive {
-      filter: grayscale(1);
-    }
-  }
-
   //this selector edits the citations and social media buttons in the abstract section
   .work-show-buttons {
     justify-content: space-between;


### PR DESCRIPTION
Ref #232; 

Before this commit, a grayscale filter was causing the Orc ID and ISNI logos for the creator, contributor, and editor to render gray.
![image](https://user-images.githubusercontent.com/95306716/210462813-c6088923-2ed7-449d-b687-ac643aa9ac01.png)

After this commit, the logos render with the respective colors.  
![image](https://user-images.githubusercontent.com/95306716/210462716-d51cae16-c6ad-4a60-b850-7c4966187839.png)

Changes proposed in this pull request:
* Orc ID logo renders as a green logo.
* ISNI logo renders as a blue logo.