### PR TITLE
Handling more fields with XML Parser

### DIFF
--- a/app/models/bulkrax/xml_etd_dc_entry.rb
+++ b/app/models/bulkrax/xml_etd_dc_entry.rb
@@ -113,10 +113,10 @@ module Bulkrax
             separated_name = name.split(/\s*,\s*/)
             next if separated_name.blank?
             # @todo consier using https://rubygems.org/gems/namae for name parsing
-            add_metadata("#{name_field_prefix}_family_name", (separated_name.first || ''))
-            add_metadata("#{name_field_prefix}_given_name", (separated_name.length > 1 ? separated_name.last : ''))
-            add_metadata("#{name_field_prefix}_name_type", 'Personal')
-            add_metadata("#{name_field_prefix}_position", position)
+            add_metadata("#{name_field_prefix}_family_name", (separated_name.first || ''), position)
+            add_metadata("#{name_field_prefix}_given_name", (separated_name.length > 1 ? separated_name.last : ''), position)
+            add_metadata("#{name_field_prefix}_name_type", 'Personal', position)
+            add_metadata("#{name_field_prefix}_position", position, position)
             position += 1
           end
         end

--- a/app/models/bulkrax/xml_etd_dc_entry.rb
+++ b/app/models/bulkrax/xml_etd_dc_entry.rb
@@ -7,7 +7,7 @@ module Bulkrax
     serialize :raw_metadata, JSON
 
     def factory_class
-      'ThesisOrDissertation'.constantize
+      ThesisOrDissertation
     end
 
     def build_metadata
@@ -22,7 +22,8 @@ module Bulkrax
         elements = record.xpath("//*[name()='#{element_name}']")
         next if elements.blank?
         elements.each do |el|
-          el.children.map(&:content).each do |content|
+          el.children.each do |child|
+            content = child.content
             add_metadata(element_name, content) if content.present?
           end
         end
@@ -45,23 +46,33 @@ module Bulkrax
       parsed_metadata['model'] = 'ThesisOrDissertation'
     end
 
+    def complicated_elements
+      %w[authoridentifier_isni authoridentifier_orcid subject identifier language provenance source relation advisor creator] # maybe embargo_date
+    end
+
     def add_complicated_fields
       add_authoridentifier
       add_subject
       add_identifier
       add_language
+      add_creator
+      add_contributor
+
       # alt identifier
     end
 
+    # @todo consider how we might put this "configuration logic" in the parser where it's a bit more visible
     def add_authoridentifier
       add_complicated_element('authoridentifier_isni', 'authoridentifier', 'uketdterms:ISNI')
       add_complicated_element('authoridentifier_orcid', 'authoridentifier', 'uketdterms:ORCID')
     end
 
+    # @todo consider how we might put this "configuration logic" in the parser where it's a bit more visible
     def add_subject
       add_complicated_element('subject', 'subject', 'dcterms:Ddc')
     end
 
+    # @todo consider how we might put this "configuration logic" in the parser where it's a bit more visible
     def add_identifier
       add_complicated_element('identifier', 'identifier', 'dcterms:DOI')
     end
@@ -74,16 +85,11 @@ module Bulkrax
       elements = record.xpath("//*[name()='#{element_name}']")
       return if elements.blank?
       elements.each do |el|
-        el.children.map(&:content).each do |content|
+        el.children.each do |child|
+          content = child.content
           add_metadata(element_label, content) if content.present? && el.attr('type') == type_value
         end
       end
-    end
-
-    def add_fields_with_names
-      add_creator
-      add_contributor
-      # etc
     end
 
     def add_creator
@@ -99,12 +105,14 @@ module Bulkrax
       return if elements.blank?
       position = 0
       elements.each do |el|
-        el.children.map(&:content).each do |content|
+        el.children.each do |child|
+          content = child.content
           names = content.split(/\s*;\s*/)
           next if names.blank?
           names.each do |name|
             separated_name = name.split(/\s*,\s*/)
             next if separated_name.blank?
+            # @todo consier using https://rubygems.org/gems/namae for name parsing
             add_metadata("#{name_field_prefix}_family_name", (separated_name.first || ''))
             add_metadata("#{name_field_prefix}_given_name", (separated_name.length > 1 ? separated_name.last : ''))
             add_metadata("#{name_field_prefix}_name_type", 'Personal')
@@ -113,10 +121,6 @@ module Bulkrax
           end
         end
       end
-    end
-
-    def complicated_elements
-      %w[authoridentifier_isni authoridentifier_orcid subject identifier language provenance source relation advisor creator] # maybe embargo_date
     end
   end
 end

--- a/app/models/bulkrax/xml_etd_dc_entry.rb
+++ b/app/models/bulkrax/xml_etd_dc_entry.rb
@@ -16,6 +16,8 @@ module Bulkrax
       self.parsed_metadata = {}
       parsed_metadata[work_identifier] = [raw_metadata[source_identifier]]
       xml_elements.each do |element_name|
+        # TODO: Refactor this so we don't have duplicate loops and multiple places that repeat
+        #       knowledge (e.g. what's the field name, or how we loop over elements)
         next if complicated_elements.include?(element_name)
         elements = record.xpath("//*[name()='#{element_name}']")
         next if elements.blank?
@@ -26,6 +28,7 @@ module Bulkrax
         end
       end
       add_model
+      add_complicated_fields
       add_visibility
       add_rights_statement
       add_admin_set_id

--- a/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
+++ b/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
@@ -96,12 +96,17 @@ RSpec.describe Bulkrax::XmlEtdDcEntry do
 
       it "assigns parsed_metadata" do
         entry.build_metadata
+        # If we don't have this, we'll fail to map content.
+        expect(entry.factory_class).to eq(ThesisOrDissertation)
 
         expect(entry.parsed_metadata.fetch('publisher')).to eq(["City, University of London"])
         expect(entry.parsed_metadata.fetch('title')).to eq(["The social history of music development in the Greek Cypriot population during 1878-1945"])
         expect(entry.parsed_metadata.fetch('model')).to eq('ThesisOrDissertation')
-        expect(entry.parsed_metadata.fetch('source')).to eq(['M Music'])
-        expect(entry.factory_class).to eq(ThesisOrDissertation)
+        expect(entry.parsed_metadata.fetch('keyword')).to eq(['M Music'])
+        creator_0_json = '[{"creator_isni":"0000000460594066","creator_family_name":"Hasikou","creator_given_name":"Anastasia","creator_name_type":"Personal","creator_position":"0"}]'
+        expect(entry.parsed_metadata.fetch('creator')).to eq([creator_0_json])
+        expect(entry.parsed_metadata.fetch('dewey')).to eq('780.95693')
+        expect(entry.parsed_metadata.fetch('language')).to eq(['eng'])
       end
     end
   end

--- a/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
+++ b/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Bulkrax::XmlEtdDcEntry do
              <type>Thesis (Ph.D.)</type>
              <qualificationlevel>doctoral</qualificationlevel>
              <isReferencedBy>https://openaccess.city.ac.uk/id/eprint/17030/</isReferencedBy>
+             <advisor>Gunn, Roger N. ; Mark, Jenkinson</advisor>
              <source>http://ethos.bl.uk/ProcessSearch.do?query=709645</source>
              <relation>018328594</relation>
              <department>Department of Music</department>
@@ -103,8 +104,11 @@ RSpec.describe Bulkrax::XmlEtdDcEntry do
         expect(entry.parsed_metadata.fetch('title')).to eq(["The social history of music development in the Greek Cypriot population during 1878-1945"])
         expect(entry.parsed_metadata.fetch('model')).to eq('ThesisOrDissertation')
         expect(entry.parsed_metadata.fetch('keyword')).to eq(['M Music'])
-        creator_0_json = '[{"creator_isni":"0000000460594066","creator_family_name":"Hasikou","creator_given_name":"Anastasia","creator_name_type":"Personal","creator_position":"0"}]'
-        expect(entry.parsed_metadata.fetch('creator')).to eq([creator_0_json])
+        creator_1_json = '{"creator_isni":"0000000460594066","creator_family_name":"Hasikou","creator_given_name":"Anastasia","creator_name_type":"Personal","creator_position":"0"}'
+        expect(entry.parsed_metadata.fetch('creator')).to eq(["[#{creator_1_json}]"])
+        contributor_0_json = '{"contributor_family_name":"Gunn","contributor_given_name":"Roger N.","contributor_name_type":"Personal","contributor_position":"0"}'
+        contributor_1_json = '{"contributor_family_name":"Mark","contributor_given_name":"Jenkinson","contributor_name_type":"Personal","contributor_position":"1"}'
+        expect(entry.parsed_metadata.fetch('contributor')).to eq(["[#{contributor_0_json},#{contributor_1_json}]"])
         expect(entry.parsed_metadata.fetch('dewey')).to eq('780.95693')
         expect(entry.parsed_metadata.fetch('language')).to eq(['eng'])
       end


### PR DESCRIPTION
## Handling more fields with XML Parser

c09b32fd81c14fd8c2dac8ff5e7871dc885134e9

Prior to this commit, nothing was calling `add_complicated_fields`.  As
a result some of the intended logic was never executed.

With this commit, we're handling a few more parser issues.

It does not, however, address other issues (such as calling the
`add_fields_with_names`).  That will need to be resolved elsewhere.

What it is, however, highlighting is that the `build_metadata` method
warrants significant reconsideration; namely it is hard to test.

_Musings_

What might that test look like?  We know that after calling
`build_metadata` we want to set the `parse_metadata` value.  What goes
into that parsing?  The raw metadata and the parser mappings (and
perhaps other things).  It would be somewhat easy to extract a class in
Bulkrax that we could pass in the raw metadata (or whatever assumptive
structure) and the parser mappings.

There remains the challenge of how we determine the factory_class, but
that's also a smaller problem.

In other words, given the raw metadata and parser, we expected the
following parsed_metadata.  Without this test, we are doomed to play a
game of whack-a-mole.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/174
- https://github.com/scientist-softserv/britishlibrary/issues/178
- https://github.com/scientist-softserv/britishlibrary/issues/186

## Adding XML parsing for creator and contributor

79c328130687add53e91971f076593fedc2285eb

This commit has five concerns:

1. Removing an unnecessary call to `String#constantize`
2. Moving methods for greater visibility
3. Adding some todo items for future consideration
4. Replacing `map.each` chain with `each`
5. Parsing creator and contributor

I consider removing unnecessary call to `String#constantize` to be
self-explanatory.

For moving methods, I wanted the "add_complicated_fields" and the
"complicated_elements" to be in close proximity.  This helps connect the
future reader to information.

I added the todo items because I think it's a bit disjointed having this
XML specific information tucked into a class when other aspects are
found in the Bulkrax field mappings.

Replacing `map.each` chain with `each` improves removes one loop (or
conversion of an array into an iterator).

Last, parsing the creator and contributor.  Or, what all we're here
for.  Without these changes, we only parse a portion of the
creator (e.g. their ISNI and/or ORCID).

With these changes we begin parsing the creator as identified in the
specs provided.  I believe the JSON object as string is the correct
format based on examing other complicated fields that were previously
parsed and rendered (e.g. `current_he_institution`).

I will need to verify this encoding with a full import.  Why a full
import?  Because I need to see the persisted Fedora object loaded and
examine it's metadata properties.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/174
- https://github.com/scientist-softserv/britishlibrary/issues/177
- https://github.com/scientist-softserv/britishlibrary/issues/178
- https://github.com/scientist-softserv/britishlibrary/issues/181
- https://github.com/scientist-softserv/britishlibrary/issues/186

## Handling multiple values for "people" fields

511305e539fc9e683aae72c842bc9ab98adde312

Prior to this commit, we were only handling the last person encountered
in the parsing.

In adding the third parameter (e.g. position) to the `#add_metadata`
call we're building a more complex object; and preventing the last
element of a multi-value field from obliterating the previous elements.

With this commit, we're also adding a new XML element to test (one that
has two people) and verifying that the parsed_metadata is as expected.

Note, there were several of us looking on as we then went through my
local environment to look at the importer's parsed and then rendered
metadata.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/174
- https://github.com/scientist-softserv/britishlibrary/issues/181
