### PR TITLE
Adding `Bulkrax::XmlEtdDcEntry` specs and spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :development do
   gem 'scss_lint', require: false
   gem 'spring', '~> 1.7'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-commands-rspec'
   # gem 'xray-rails' # when using this gem, know that sidekiq will not work
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1126,6 +1126,8 @@ GEM
       net-http-persistent (~> 4.0, >= 4.0.1)
       rdf (~> 3.1)
     spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -1286,6 +1288,7 @@ DEPENDENCIES
   simplecov
   solr_wrapper (~> 2.0)
   spring (~> 1.7)
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tether-rails
   turbolinks (~> 5)

--- a/app/models/bulkrax/xml_etd_dc_entry.rb
+++ b/app/models/bulkrax/xml_etd_dc_entry.rb
@@ -2,7 +2,7 @@
 
 require 'nokogiri'
 module Bulkrax
-  # Generic XML Entry
+  # Custom XML Entry for British Library's Electronic Theses and Dissertations.
   class XmlEtdDcEntry < XmlEntry
     serialize :raw_metadata, JSON
 

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
+++ b/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Bulkrax
+  module SpecHelper
+    ##
+    # @api private
+    #
+    # A spec helper method for building Bulrax::Entry instances in downstream bulkrax applications.
+    #
+    # @params identifier [#to_s] The identifier of this object
+    # @params adata [String] The "data" value for the #raw_metadata of the {Bulkrax::Entry}.
+    # @params parser_class_name [String] One of the the named parsers of {Bulkrax.parsers}
+    # @params entry_class [Class<Bulkrax::Entry>]
+    # @param collection [Array<String>]
+    # @param children [Array<String>]
+    #
+    # @return [Bulkrax::Entry]
+    #
+    # @todo Extract this method back into a Bulkrax::SpecHelper module.
+    # @todo This could replace some of the factories in Bulkrax's spec suite.
+    # @note This presently assumes an XML oriented format; or "We haven't checked this against CSV".
+    #       And the signature of this method should be considered volatile.
+    #
+    # rubocop:disable Metrics/ParameterLists
+    def self.build_entry_for(identifier:, data:, parser_class_name:, entry_class:, collection: [], children: [])
+      importer = Bulkrax::Importer.new(
+        name: "Test importer for identifier #{identifier}",
+        admin_set_id: "admin_set/default",
+        user_id: 1,
+        limit: 1,
+        parser_klass: parser_class_name,
+        field_mapping: Bulkrax.field_mappings.fetch(parser_class_name),
+        parser_fields: {}
+      )
+
+      raw_metadata = {
+        importer.parser.source_identifier.to_s => identifier,
+        "data" => data,
+        "collection" => collection,
+        "children" => children
+      }
+
+      entry_class.new(
+        importerexporter: importer,
+        identifier: identifier,
+        raw_metadata: raw_metadata
+      )
+    end
+    # rubocop:enable Metrics/ParameterLists
+  end
+end
+
+RSpec.describe Bulkrax::XmlEtdDcEntry do
+  # To run this fast in Docker:
+  #
+  # 1. spring start
+  # 2. spring rspec spec/models/bulkrax/xml_etd_dc_entry_spec.rb
+  describe "#build_metadata" do
+    context "source http://ethos.bl.uk/ProcessSearch.do?query=709645" do
+      subject(:entry) do
+        Bulkrax::SpecHelper.build_entry_for(
+          entry_class: described_class,
+          identifier: identifier,
+          data: data,
+          parser_class_name: "Bulkrax::XmlEtdDcParser"
+        )
+      end
+
+      let(:identifier) { "http://ethos.bl.uk/ProcessSearch.do?query=709645" }
+      let(:data) do
+        %(
+           <uketddc schemaLocation="http://naca.central.cranfield.ac.uk/ethos-oai/2.0/ http://naca.central.cranfield.ac.uk/ethos-oai/2.0/uketd_dc.xsd">
+             <creator>Hasikou, Anastasia</creator>
+             <authoridentifier type="uketdterms:ISNI">0000000460594066</authoridentifier>
+             <issued>01/01/2017</issued>
+             <subject type="dcterms:Ddc">780.95693</subject>
+             <coverage>M Music</coverage>
+             <abstract>This thesis examines relationships between the music of the Greek community of Cyprus and the social...</abstract>
+             <language type="dcterms:ISO639-2">eng</language>
+             <institution>City, University of London</institution>
+             <publisher>City, University of London</publisher>
+             <title>The social history of music development in the Greek Cypriot population during 1878-1945</title>
+             <type>Thesis (Ph.D.)</type>
+             <qualificationlevel>doctoral</qualificationlevel>
+             <isReferencedBy>https://openaccess.city.ac.uk/id/eprint/17030/</isReferencedBy>
+             <source>http://ethos.bl.uk/ProcessSearch.do?query=709645</source>
+             <relation>018328594</relation>
+             <department>Department of Music</department>
+             <accessRights>true</accessRights>
+             <provenance>oai:openaccess.city.ac.uk:17030</provenance>
+           </uketddc>
+        )
+      end
+
+      it "assigns parsed_metadata" do
+        entry.build_metadata
+
+        expect(entry.parsed_metadata.fetch('publisher')).to eq(["City, University of London"])
+        expect(entry.parsed_metadata.fetch('title')).to eq(["The social history of music development in the Greek Cypriot population during 1878-1945"])
+        expect(entry.parsed_metadata.fetch('model')).to eq('ThesisOrDissertation')
+        expect(entry.parsed_metadata.fetch('source')).to eq(['M Music'])
+        expect(entry.factory_class).to eq(ThesisOrDissertation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit contains two components:

1. Adding tests for `Bulkrax::XmlEtdDcEntry`
2. Adding spring-commands-rspec

**Adding tests for `Bulkrax::XmlEtdDcEntry`**

Given the complexity of the metadata, with complex objects and an xml document with multiple namespaces, I want to introduce tests that can help us verify the mapping process from raw metadata to parsed metadata.

These tests are the rudimentary basics, from which I'll build more; they are mostly there to show that things are working.

**Adding spring-commands-rspec**

*Note:* Spring is the culprit of many problems in Samvera land. However a judicious use of spring can greatly expedite testing.

As spring is a culprit, I only created the spring binstub for `bin/rspec`.  It's probably okay to generally run rspec with spring; however my recommendation is be explicit about turning it on (via `spring start`) and then turn it off (via `spring stop`).

Given all of that preamble and caution, why spring?

Let's look at the following example in which I start spring.  The `spring start` command loads the rails application; and pays that heavy cost once.  From there on out you can keep calling

```shell
$ docker compose web bash

> spring start
Booting application

> bin/ rspec spec/models/bulkrax/xml_etd_dc_entry_spec.rb
Finished in 1.32 seconds (files took 8.07 seconds to load)

> spring rspec spec/models/bulkrax/xml_etd_dc_entry_spec.rb
Finished in 1.28 seconds (files took 7.57 seconds to load)
```

```shell
$ docker compose web bash

> rspec spec/models/bulkrax/xml_etd_dc_entry_spec.rb
Finished in 1.27 seconds (files took 1 minute 6.4 seconds to load)

> rspec spec/models/bulkrax/xml_etd_dc_entry_spec.rb
Finished in 1.27 seconds (files took 1 minute 6.4 seconds to load)
```

The boot time drops by one minute.  Having a 9 second feedback loop for testing is far more bearable than a 70 second feedback loop.

Related Issues:

- https://github.com/samvera-labs/bulkrax/issues/714
- https://github.com/scientist-softserv/britishlibrary/issues/174
