### PR TITLE
[i181] Capturing contributor_type for XML import

### DIFF
--- a/app/parsers/bulkrax/xml_etd_dc_parser.rb
+++ b/app/parsers/bulkrax/xml_etd_dc_parser.rb
@@ -6,12 +6,25 @@ module Bulkrax
       Bulkrax::XmlEtdDcEntry
     end
 
+    # @note We can remove these when we go to something past Bulkrax v4.4.0 (or at least include SHA c514810d90653905ad6d6809eabe8fcfe7ff02d7)
     # @note this not yet supported yet in bulkrax
     def file_set_entry_class; end
 
     def create_relationships
       ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
     end
+
+    # @note We can remove these when we go to something past Bulkrax v4.4.0 (or at least include SHA c514810d90653905ad6d6809eabe8fcfe7ff02d7)
+    # @todo not yet supported
+    def collection_entry_class; end
+
+    # @note We can remove these when we go to something past Bulkrax v4.4.0 (or at least include SHA c514810d90653905ad6d6809eabe8fcfe7ff02d7)
+    # @todo not yet supported
+    def create_collections; end
+
+    # @note We can remove these when we go to something past Bulkrax v4.4.0 (or at least include SHA c514810d90653905ad6d6809eabe8fcfe7ff02d7)
+    # @todo not yet supported
+    def create_file_sets; end
 
     # Override bulkrax v4.4.0 to address bug that is fixed in
     # https://github.com/samvera-labs/bulkrax/pull/713

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -190,6 +190,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
         'contributor_family_name' => { from: ['advisor'], object: 'contributor' },
         'contributor_given_name' => { from: ['advisor'], object: 'contributor' },
         'contributor_name_type' => { from: ['advisor'], object: 'contributor' },
+        'contributor_type' => { from: ['advisor'], object: 'contributor' },
         'contributor_position' => { from: ['advisor'], object: 'contributor' },
         'creator_family_name' => { from: ['creator'], object: 'creator' },
         'creator_given_name' => { from: ['creator'], object: 'creator' },

--- a/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
+++ b/spec/models/bulkrax/xml_etd_dc_entry_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe Bulkrax::XmlEtdDcEntry do
         expect(entry.parsed_metadata.fetch('keyword')).to eq(['M Music'])
         creator_1_json = '{"creator_isni":"0000000460594066","creator_family_name":"Hasikou","creator_given_name":"Anastasia","creator_name_type":"Personal","creator_position":"0"}'
         expect(entry.parsed_metadata.fetch('creator')).to eq(["[#{creator_1_json}]"])
-        contributor_0_json = '{"contributor_family_name":"Gunn","contributor_given_name":"Roger N.","contributor_name_type":"Personal","contributor_position":"0"}'
-        contributor_1_json = '{"contributor_family_name":"Mark","contributor_given_name":"Jenkinson","contributor_name_type":"Personal","contributor_position":"1"}'
+        contributor_0_json = '{"contributor_family_name":"Gunn","contributor_given_name":"Roger N.","contributor_name_type":"Personal","contributor_position":"0","contributor_type":"Supervisor"}'
+        contributor_1_json = '{"contributor_family_name":"Mark","contributor_given_name":"Jenkinson","contributor_name_type":"Personal","contributor_position":"1","contributor_type":"Supervisor"}'
         expect(entry.parsed_metadata.fetch('contributor')).to eq(["[#{contributor_0_json},#{contributor_1_json}]"])
         expect(entry.parsed_metadata.fetch('dewey')).to eq('780.95693')
         expect(entry.parsed_metadata.fetch('language')).to eq(['eng'])


### PR DESCRIPTION
This commit contains two things:

1. Method definitions for expected implementations in Bulkrax.
2. Adding mapping to contributor_type for ETD's XML metadata.

**Method Definitions**

I encountered `UndefinedMethodError` when I was re-running an importer. In [Bulkrax's XML Parser (as of c3a63813)][1] there are method definitions that override the [Application Parser's methods][2].  In updating this, we conform to the interface and implement the methods of that interface.

**Mapping to contributor_type**

Prior to this commit, our [CSV parser handled the contributor_type][3] but our XML parser did not.

With this commit, our XML parser now considered `contributor_type` a valid field.  And our XML entry now appends that field value to the complex contributor object.  I have also put in place a guard condition, in part to assure that we have a valid entry; but also to highlight a connect between this field and the UI where we set the field.

Last we need to verify that this change propagates to the UI, both show and edit page; I did this locally but our QA will need to handle that.

I referenced http://ethos.bl.uk/ProcessSearch.do?query=629358 for this test.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/181

[1]:https://github.com/samvera-labs/bulkrax/blob/c3a638139be3ec537aaee250489c7e3c8a4309f3/app/parsers/bulkrax/xml_parser.rb#L9-L19

[2]:https://github.com/samvera-labs/bulkrax/blob/c3a638139be3ec537aaee250489c7e3c8a4309f3/app/parsers/bulkrax/application_parser.rb#L167-L184

[3]:https://github.com/scientist-softserv/britishlibrary/blob/b73202952cc384743df4079b868366dbedc65fe1/config/initializers/bulkrax.rb#L79
