### PR TITLE
[i227] Addressing Tenant security issue in Bulkrax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 
 # Bulkrax
 group :bulkrax do
-  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', tag: 'v4.4.0'
+  gem 'bulkrax', "~> 4.4.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: 'b8905d8644617d23b97a7346dba4a223537502d1'
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: db7d32ca0392d18c48a8593d28f050332557d9ca
-  tag: v4.4.0
+  revision: b8905d8644617d23b97a7346dba4a223537502d1
+  ref: b8905d8644617d23b97a7346dba4a223537502d1
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)
@@ -1218,7 +1218,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   bootstrap-datepicker-rails
   browse-everything (~> 1.1.2)
-  bulkrax!
+  bulkrax (~> 4.4.0)!
   byebug
   capybara
   capybara-screenshot (~> 1.0)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,4 +57,14 @@ class Ability
     @user_groups |= ['registered'] if !current_user.new_record? && current_user.roles.count.positive?
     @user_groups
   end
+
+  # @see https://github.com/samvera-labs/bulkrax/pull/707
+  def can_import_works?
+    can_create_any_work?
+  end
+
+  # @see https://github.com/samvera-labs/bulkrax/pull/707
+  def can_export_works?
+    can_create_any_work?
+  end
 end


### PR DESCRIPTION
This commit does one primary thing, leverages Bulkrax to v4.4.0+.

We are in the process of releasing Hyrax 5.0; however with a reported issue in the British Library repository, we want to explore using a version that should resolve that bug; without waiting for a release.

From v4.4.0 to the ref `b8905d8644617d23b97a7346dba4a223537502d1` there appears to be only one breaking change; namely the change for adding permissions to Bulkrax.

Related to:

- https://github.com/samvera-labs/bulkrax/pull/707
- https://github.com/scientist-softserv/britishlibrary/issues/227