### PR TITLE
candidate to fix #245 by ensuring dc config for tenant is always used

### DIFF
--- a/config/initializers/hyrax-doi.rb
+++ b/config/initializers/hyrax-doi.rb
@@ -168,3 +168,18 @@ Hyrax::Identifier::Dispatcher.class_eval do
     object
   end
 end
+
+# Forces DataCiteRegistrar to initializew a new client everytime. 
+# A fix for #245 https://github.com/scientist-softserv/britishlibrary/issues/245
+# Prevents leaching of datacite config between tenants when minting DOIs by ensuring
+# that the datacite credentials always come from the account that kicked the job off
+Hyrax::DOI::DataCiteRegistrar.class_eval do
+
+  def client 
+    current_tenant = Apartment::Tenant.current
+    @datacite_endpoint ||= Account.find_by(tenant: current_tenant).data_cite_endpoint
+
+    Hyrax::DOI::DataCiteClient.new(username: @datacite_endpoint.username, password: @datacite_endpoint.password, prefix: @datacite_endpoint.prefix, mode: @datacite_endpoint.mode)
+  end
+
+end

--- a/config/initializers/hyrax-doi.rb
+++ b/config/initializers/hyrax-doi.rb
@@ -175,14 +175,14 @@ end
 # that the datacite credentials always come from the account that kicked the job off
 Hyrax::DOI::DataCiteRegistrar.class_eval do
 
-  def initialize(builder: Hyrax::Identifier::Builder.new(prefix: self.prefix))
+  def initialize(builder: nil)
     current_tenant = Apartment::Tenant.current
     datacite_endpoint ||= Account.find_by(tenant: current_tenant).data_cite_endpoint
     self.username = datacite_endpoint.username
     self.password = datacite_endpoint.password
     self.prefix = datacite_endpoint.prefix
     self.mode = datacite_endpoint.mode
-    super
+    super(builder: Hyrax::Identifier::Builder.new(prefix: self.prefix))
   end
 
   def client 

--- a/config/initializers/hyrax-doi.rb
+++ b/config/initializers/hyrax-doi.rb
@@ -175,11 +175,18 @@ end
 # that the datacite credentials always come from the account that kicked the job off
 Hyrax::DOI::DataCiteRegistrar.class_eval do
 
-  def client 
+  def initialize(builder: Hyrax::Identifier::Builder.new(prefix: self.prefix))
     current_tenant = Apartment::Tenant.current
-    @datacite_endpoint ||= Account.find_by(tenant: current_tenant).data_cite_endpoint
+    datacite_endpoint ||= Account.find_by(tenant: current_tenant).data_cite_endpoint
+    self.username = datacite_endpoint.username
+    self.password = datacite_endpoint.password
+    self.prefix = datacite_endpoint.prefix
+    self.mode = datacite_endpoint.mode
+    super
+  end
 
-    Hyrax::DOI::DataCiteClient.new(username: @datacite_endpoint.username, password: @datacite_endpoint.password, prefix: @datacite_endpoint.prefix, mode: @datacite_endpoint.mode)
+  def client 
+    Hyrax::DOI::DataCiteClient.new(username: self.username, password: self.password, prefix: self.prefix, mode: self.mode)
   end
 
 end


### PR DESCRIPTION
Fixes #245 ; 

Present tense short summary (50 characters or less)

When DataCiteRegistrar created a DataCiteClient it used class attributes that could be cached between two Registration events even if those two events were instigated by two different tenants. This change fetches the DC config from the current tenant's data_cite_endpoint before creating the DataCiteClient.

