### PR TITLE
Fixed add to collection button

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -70,7 +70,13 @@
           <% else %>
             <div class="col-md-7 hyc-description">
             <% end %>
-            <div>
+            <section
+              data-source="my"
+              data-id="<%= @presenter.id %>"
+              data-colls-hash="<%= @presenter.available_parent_collections(scope: controller) %>"
+              data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(@presenter.id) %>"
+              data-post-delete-url="<%= hyrax.dashboard_collection_path(@presenter.id) %>">
+
               <% if @presenter.banner_file.blank? && @presenter.logo_record.present? %>
                 <h1 class="mt-0 pt-40"><%= @presenter.title.first %></h1>
               <% else %>
@@ -80,7 +86,7 @@
               <div class='show-actions-container'>
                 <%= render "hyrax/dashboard/collections/show_actions", presenter: @presenter %>
               </div>
-            </div>
+            </section>
             <% if @members_count > 0 || params['cq'] == nil %>
               <div class="pt-20">
                 <%= render 'collection_description', presenter: @presenter %>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -8,6 +8,7 @@
                 class: 'btn btn-primary' %>
 <% end %>
 <% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>
+    <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
 <!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
     <%= button_tag '',
                   class: 'btn btn-primary add-to-collection',


### PR DESCRIPTION
Before this commit, the JS assumed the a section tag with data attributes. Without that, the button did not work.

With this commit, the data attributes were added as well as a partial to restore functionality of the add to collection button.

Add  to collection modal:
![image](https://user-images.githubusercontent.com/95306716/215618800-2ebff4a4-c666-4167-9f76-a9142a092d10.png)

Collection added as subcollection:
![image](https://user-images.githubusercontent.com/95306716/215619140-90aebf42-a1c8-4cff-a3e9-8148ef203ea6.png)


We also needed to ensure we added the modal_add_to_collection from: https://github.com/scientist-softserv/utk-hyku/blame/d6260ee598f11ae4ee201d0880ff0d893447e271/app/views/hyrax/dashboard/collections/_show_actions.html.erb#L11

Ref: #133