### PR TITLE
Adding SHA to deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,5 @@
 name: "Deploy"
-run-name: Deploy (${{ github.ref_name }} -> ${{ inputs.environment }}) by @${{ github.actor }}
+run-name: Deploy (${{ github.ref_name }} -> ${{ inputs.environment }}) by @${{ github.actor }} with SHA ${{ github.sha}}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Knowing the deployed branch is useful, but knowing it's SHA can be even more useful to understand timing.

See https://docs.github.com/en/actions/learn-github-actions/variables

