### PR TITLE
Add yarn install towards the end of build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ COPY --chown=1001:101 $APP_PATH/bin/db-migrate-seed.sh /app/samvera/
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 
 ARG HYKU_BULKRAX_ENABLED="true"
-RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
 CMD ./bin/web
 
 FROM hyku-web as hyku-worker


### PR DESCRIPTION
Using Hyku as a model, we are adding `yarn install` at the end of the build sequence, after assets precompile to see if it build currently on deploys.  This still doesn't seem to solve it for local dev environments though. 

Hyku ref: https://github.com/samvera/hyku/commit/a2a0f68d28d55280eac012c53f0fc3c3bec1796d