### PR TITLE
Hot Fix: "undefined local variable or method `section`"

### DIFF
--- a/app/views/records/show_fields/_contributor.html.erb
+++ b/app/views/records/show_fields/_contributor.html.erb
@@ -38,7 +38,7 @@ https://github.com/samvera/hyrax/blob/v2.9.6/app/views/records/show_fields/_cont
   <% end %>
   <% if array_of_hash.length > 5 %>
     <li>
-      <button id="collection-details-contributor-collapse" class="<%= section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-contributor.collapse" aria-expanded="false" aria-controls="collapse">
+      <button id="collection-details-contributor-collapse" class="<%= defined?(section) && section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-contributor.collapse" aria-expanded="false" aria-controls="collapse">
         <span>Show more</span>
         <span style='display:none'>Close list</span>
       </button>

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE Hyrax 2.9.6 to make more fields for creator 
+<%# OVERRIDE Hyrax 2.9.6 to make more fields for creator
 https://github.com/samvera/hyrax/blob/v2.9.6/app/views/records/show_fields/_creator.html.erb %>
 
 <% array_of_hash = JSON.parse record.creator.first %>
@@ -38,7 +38,7 @@ https://github.com/samvera/hyrax/blob/v2.9.6/app/views/records/show_fields/_crea
   <% end %>
   <% if array_of_hash.length > 5 %>
     <li>
-      <button id="collection-details-creator-collapse" class="<%= section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-creator.collapse" aria-expanded="false" aria-controls="collapse">
+      <button id="collection-details-creator-collapse" class="<%= defined?(section) && section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-creator.collapse" aria-expanded="false" aria-controls="collapse">
         <span>Show more</span>
         <span style='display:none'>Close list</span>
       </button>


### PR DESCRIPTION
[In Slack][1] this was identified as something to quickly fix.

The underlying problem is that the `section` local for the "_creator" partial was not being passed to this partial.

The failure comes from the [Hyrax::PresenterRender][2] not passing the `section` as a local variable to the template.  To unblock the client, I'm adding a check for `section` before attempting to test equality.

Below are the three `app/views` that have a `section ==` logic check.

For this commit, I'm amending `_contributor` and `_creator` because they are likely rendered together (based on my read of the `Hyrax::PresenterRender`).  Whereas the `ubiquity/creator` partial is rendered through other pathways.

```shell
> rg "section ==" ~/git/britishlibrary

app/views/records/show_fields/_creator.html.erb:
<button id="collection-details-creator-collapse" class="<%= section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-creator.collapse" aria-expanded="false" aria-controls="collapse">

app/views/records/show_fields/_contributor.html.erb:
<button id="collection-details-contributor-collapse" class="<%= section == 'header' ? 'btn-secondary' : 'collapse-fields' %>" data-toggle="collapse" data-target=".collection-details-contributor.collapse" aria-expanded="false" aria-controls="collapse">

app/views/shared/ubiquity/creator/_show_array_hash.html.erb:
<button id="<%= section %>-creator-collapse" class="<%= section == 'header' ? 'btn-secondary collapse-fields' : 'collapse-fields' %>" data-toggle="collapse" data-target=".<%= section %>-creator.collapse" aria-expanded="false" aria-controls="collapse">
```

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/284
- https://scientist-inc.sentry.io/issues/3941511830

[1]: https://assaydepot.slack.com/archives/C0313NK2LJ0/p1676636500470559?thread_ts=1676568931.180859&cid=C0313NK2LJ0

[2]: https://github.com/samvera/hyrax/blob/64c0bbf0dc0d3e1b49f040b50ea70d177cc9d8f6/app/presenters/hyrax/presenter_renderer.rb#L39-L45

