### PR TITLE
Addressing exporter memory issue in Bulkrax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,8 +100,9 @@ group :development do
   # gem 'xray-rails' # when using this gem, know that sidekiq will not work
 end
 
-# Bulkrax
-gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'main'
+# Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have
+#            a quick scan of what version we're assuming/working with.
+gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '4cf0207fc7a04d4ca8061e2637a9e332efcddcc8'
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 74576c457909f56e4f2a42cede113bbadcdeedf9
-  branch: main
+  revision: 4cf0207fc7a04d4ca8061e2637a9e332efcddcc8
+  ref: 4cf0207fc7a04d4ca8061e2637a9e332efcddcc8
   specs:
-    bulkrax (5.0.0)
+    bulkrax (5.1.0)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)
@@ -1220,7 +1220,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   bootstrap-datepicker-rails
   browse-everything (~> 1.1.2)
-  bulkrax (~> 5.0.0)!
+  bulkrax (~> 5.1.0)!
   byebug
   capybara
   capybara-screenshot (~> 1.0)


### PR DESCRIPTION
Below is the list of enhancements and features this upgrade will bring. In particulare we're interested in [4cf0207][1].

```shell
❯ cd ~/git/bulkrax; git checkout main; git pull main
❯ git slog --no-merges 74576c457909f56e4f2a42cede113bbadcdeedf9..
* 4cf0207 — Adding `Bulkrax::ParserExportRecordSet` Jeremy Friesen, (2023-02-22) (HEAD -> main, origin/main, origin/HEAD)
* 96c176a — Favoring non-deprecated method name Jeremy Friesen, (2023-02-21)
* a7690ed — minor version bump to 5.1.0 Shana Moore, (2023-02-21) (tag: v5.1.0)
* 491a6ae — instrament realtionship job to solve memory leak Rob Kaufman, (2023-02-20)
* af91434 — exporter errors for non hyrax apps Lea Ann Bradford, (2023-02-17)
* c80745c — Expanding `Bulkrax::EntrySpecHelper` to handle collections Jeremy Friesen, (2023-02-17)
* facccbe — Capturing record and header metadata for OAI parser Jeremy Friesen, (2023-02-16)
```

Further, I have amended the `gem` declaration of Bulkrax to add a "hint" to the expected version.  Having this "hint" helps when sleuthing out the current state of code (e.g. we don't have to remember/check which SHA is contained in which tags).

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/pull/749

[1]: https://github.com/samvera-labs/bulkrax/commit/4cf0207