### PR TITLE
Override EmbargoActor.destroy to mimic DOIActor behaviour on embargo …

### DIFF
--- a/app/actors/hyrax/actors/doi_actor.rb
+++ b/app/actors/hyrax/actors/doi_actor.rb
@@ -25,7 +25,7 @@ module Hyrax
       # @see Hyrax::Actors::AbstractActor
       def create(env)
         # Assume the model actor has already run and saved the work
-        create_or_update_doi(env.curation_concern) && next_actor.create(env)
+         Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(env.curation_concern) && next_actor.create(env)
       end
 
       ##
@@ -37,23 +37,9 @@ module Hyrax
         apply_save_data_to_curation_concern(env)
         save(env)
 
-        create_or_update_doi(env.curation_concern) && next_actor.update(env)
+        Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(env.curation_concern) && next_actor.update(env)
       end
 
-      private
-
-        def create_or_update_doi(work)
-          # OVERRIDE Hyrax-DOI 0.2.0 to stop register jobs being started when option to register is "do not mint"
-          # By checking that the doi_status_when_public is one of the valid Hyrax::DOI::DataCiteRegistrar::STATES
-          return true unless doi_enabled_work_type?(work) && Flipflop.enabled?(:doi_minting) && work.doi_status_when_public.in?(Hyrax::DOI::DataCiteRegistrar::STATES)
-
-          Hyrax::DOI::RegisterDOIJob.perform_later(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts)
-        end
-
-        # Check if work is DOI enabled
-        def doi_enabled_work_type?(work)
-          work.class.ancestors.include? Hyrax::DOI::DOIBehavior
-        end
     end
   end
 end

--- a/app/actors/hyrax/actors/doi_actor.rb
+++ b/app/actors/hyrax/actors/doi_actor.rb
@@ -25,7 +25,7 @@ module Hyrax
       # @see Hyrax::Actors::AbstractActor
       def create(env)
         # Assume the model actor has already run and saved the work
-         Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(env.curation_concern) && next_actor.create(env)
+        Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(env.curation_concern) && next_actor.create(env)
       end
 
       ##
@@ -39,7 +39,6 @@ module Hyrax
 
         Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(env.curation_concern) && next_actor.update(env)
       end
-
     end
   end
 end

--- a/app/actors/hyrax/actors/embargo_actor_decorator.rb
+++ b/app/actors/hyrax/actors/embargo_actor_decorator.rb
@@ -1,0 +1,10 @@
+module Hyrax
+  module Actors
+    module EmbargoActorDecorator
+      def destroy
+        super
+        Hyrax::DOI::RegisterDOIJob.conditionally_create_or_update_doi_for(work)
+      end
+    end
+  end
+end

--- a/app/jobs/hyrax/doi/register_doi_job.rb
+++ b/app/jobs/hyrax/doi/register_doi_job.rb
@@ -45,7 +45,7 @@ module Hyrax
         return true unless work.class.ancestors.include?(Hyrax::DOI::DOIBehavior) && Flipflop.enabled?(:doi_minting) && work.doi_status_when_public.in?(Hyrax::DOI::DataCiteRegistrar::STATES)
 
         Hyrax::DOI::RegisterDOIJob.perform_later(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts)
-      end 
+      end
     end
   end
 end

--- a/app/jobs/hyrax/doi/register_doi_job.rb
+++ b/app/jobs/hyrax/doi/register_doi_job.rb
@@ -36,6 +36,16 @@ module Hyrax
       def action(model, e)
         "DOI update filed for <a href='#{polymorphic_url(model)}'>#{model.title.first}</a>. Datacite said '#{e.message}'"
       end
+
+      # OVERRIDE Hyrax-DOI 0.2.0 to stop register jobs being started when option to register is "do not mint"
+      # By checking that the doi_status_when_public is one of the valid Hyrax::DOI::DataCiteRegistrar::STATES
+      # Also move this method to RegisterDOIJob to be accessible from DOI and Embargo Actors
+
+      def self.conditionally_create_or_update_doi_for(work)
+        return true unless work.class.ancestors.include?(Hyrax::DOI::DOIBehavior) && Flipflop.enabled?(:doi_minting) && work.doi_status_when_public.in?(Hyrax::DOI::DataCiteRegistrar::STATES)
+
+        Hyrax::DOI::RegisterDOIJob.perform_later(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts)
+      end 
     end
   end
 end

--- a/config/initializers/hyrax-doi.rb
+++ b/config/initializers/hyrax-doi.rb
@@ -190,3 +190,33 @@ Hyrax::DOI::DataCiteRegistrar.class_eval do
   end
 
 end
+
+Hyrax::Actors::EmbargoActor.class_eval do
+
+  # Update the visibility of the work to match the correct state of the embargo, then clear the embargo date, etc.
+  # Saves the embargo and the work
+  # Overrides hyrax 2.9.6 (app/actors/embargo_actor.rb)
+  def destroy
+    work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
+    work.deactivate_embargo!
+    work.embargo.save!
+    work.save!
+    # When we destroy the embargo we need to run RegisterDOIJob as the hyrax visiblity may have an impact on the doi status
+    create_or_update_doi(work)
+  end
+
+  # Horrendous duplication of private DOIActor methods
+  def create_or_update_doi(work)
+    # OVERRIDE Hyrax-DOI 0.2.0 to stop register jobs being started when option to register is "do not mint"
+    # By checking that the doi_status_when_public is one of the valid Hyrax::DOI::DataCiteRegistrar::STATES
+    return true unless doi_enabled_work_type?(work) && Flipflop.enabled?(:doi_minting) && work.doi_status_when_public.in?(Hyrax::DOI::DataCiteRegistrar::STATES)
+
+    Hyrax::DOI::RegisterDOIJob.perform_later(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts)
+  end
+
+  # Check if work is DOI enabled
+  def doi_enabled_work_type?(work)
+    work.class.ancestors.include? Hyrax::DOI::DOIBehavior
+  end
+
+end


### PR DESCRIPTION
…deactivation

Fixes #140 

Present tense short summary (50 characters or less)

If an item has visibility of embargoed, doi gem will set status to registered on datacite even if statis_when_public is findable. Once the item is out of embargo this needs to be updated by calling the RegisterDOIJob again. 

This will work in generally cases in which the status_when_public is updated "by hand" for embargoed items... e.g. from draft to findable.

@samvera/hyku-code-reviewers
