### PR TITLE
add init argument so that the isni is judiciciously managed

### DIFF
--- a/app/assets/javascripts/ubiquity/contributor.js
+++ b/app/assets/javascripts/ubiquity/contributor.js
@@ -37,43 +37,49 @@ $(document).on('turbolinks:load', function() {
 // display a new contributor section on the new or edit form
 $(document).on('turbolinks:load', function() {
   return $('body').on('change', '.ubiquity_contributor_name_type', function() {
-    displayContributorFields($(this.parentElement), this.value);
+    displayContributorFields($(this.parentElement), this.value, false);
   });
 });
 
 // set saved values in the contributor section(s) on the edit work form
 $(document).on('turbolinks:load', function() {
   $('.ubiquity_contributor_name_type').each(function() {
-    displayContributorFields($(this).parent(), this.value);
+    displayContributorFields($(this).parent(), this.value, true);
   })
 });
 
-function displayContributorFields(self, value) {
+// init arg will tell us if we have been called as part of 
+// initialisation of form, or on a change to the name_type selector
+function displayContributorFields(self, value, init) {
   if (value == 'Personal') {
-    hideContributorOrganization(self);
+    hideContributorOrganization(self, init);
 
   } else if (value == 'Organisational') {
-    hideContributorPersonal(self);
+    hideContributorPersonal(self, init);
 
   } else {
     $('.ubiquity_contributor_name_type').last().val('Personal').change();
   }
 }
 
-function hideContributorOrganization(self) {
+function hideContributorOrganization(self, init) {
   self.siblings('.ubiquity_personal_fields').show();
   self.siblings('.ubiquity_organization_fields').find('.ubiquity_contributor_organization_name').last().val('');
-  self.siblings('.isni_input_group').find('.ubiquity_contributor_isni').last().val('');
+  if (init === false) {
+    self.siblings('.isni_input_group').find('.ubiquity_contributor_isni').last().val('');
+  }
   self.siblings('.ubiquity_organization_fields').find('.ubiquity_contributor_organization_name').last().removeAttr('required');
   self.siblings('.ubiquity_organization_fields').hide();
 }
 
-function hideContributorPersonal(self) {
+function hideContributorPersonal(self, init) {
   self.siblings('.ubiquity_organization_fields').show();
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_contributor_family_name').last().val('').removeAttr('required');
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_contributor_given_name').last().val('').removeAttr('required');
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_contributor_orcid').last().val('');
-  self.siblings('.isni_input_group').find('.ubiquity_contributor_isni').last().val('');
+  if (init === false) {
+    self.siblings('.isni_input_group').find('.ubiquity_contributor_isni').last().val('');
+  }
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_contributor_institutional_relationship').last().val('');
   self.siblings('.ubiquity_personal_fields').hide();
 }

--- a/app/assets/javascripts/ubiquity/editor.js
+++ b/app/assets/javascripts/ubiquity/editor.js
@@ -37,44 +37,49 @@ $(document).on('turbolinks:load', function() {
 // display a new editor section on the new or edit form
 $(document).on('turbolinks:load', function() {
   return $('body').on('change', '.ubiquity_editor_name_type', function() {
-    displayEditorFields($(this), this.value);
+    displayEditorFields($(this), this.value, false);
   });
 });
 
 // set saved values in the editor section(s) on the edit work form
 $(document).on('turbolinks:load', function() {
   $('.ubiquity_editor_name_type').each(function() {
-    displayEditorFields($(this), this.value);
+    displayEditorFields($(this), this.value, true);
   })
 });
 
 // default the editor type to personal
 // if one hasn't been selected
-function displayEditorFields(self, value) {
+// init arg added
+function displayEditorFields(self, value, init) {
   if (value == 'Personal') {
-    hideEditorOrganization(self);
+    hideEditorOrganization(self, init);
 
   } else if (value == 'Organisational') {
-    hideEditorPersonal(self);
+    hideEditorPersonal(self, init);
 
   } else {
     $('.ubiquity_editor_name_type').last().val('Personal').change();
   }
 }
 
-function hideEditorOrganization(self) {
+function hideEditorOrganization(self, init) {
   self.siblings('.ubiquity_personal_fields').show();
   self.siblings('.ubiquity_organization_fields').find('.ubiquity_editor_organization_name').last().val('');
-  self.siblings('.isni_input_group').find('.ubiquity_editor_isni').last().val('');
+  if (init === false) {
+    self.siblings('.isni_input_group').find('.ubiquity_editor_isni').last().val('');
+  }
   self.siblings('.ubiquity_organization_fields').hide();
 }
 
-function hideEditorPersonal(self) {
+function hideEditorPersonal(self, init) {
   self.siblings('.ubiquity_organization_fields').show();
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_editor_orcid').last().val('');
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_editor_family_name').last().val('');
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_editor_given_name').last().val('');
-  self.siblings('.isni_input_group').find('.ubiquity_editor_isni').last().val('');
+  if (init === false) {
+    self.siblings('.isni_input_group').find('.ubiquity_editor_isni').last().val('');
+  }
   self.siblings('.ubiquity_personal_fields').find('.ubiquity_editor_institutional_relationship').last().val('');
   self.siblings('.ubiquity_personal_fields').hide();
 }


### PR DESCRIPTION
Fixes #300; 

We clear isni for contributor and editor when the nameType changes as before but _not_ when the form is first loaded.

Was sorted for creator a while back: 9a985e1