### PR TITLE
make collection searches search all fields, fix original_doi in add_s…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -169,7 +169,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('date_submitted', :stored_searchable)
     config.add_show_field solr_name('related_url', :stored_searchable)
     config.add_show_field solr_name('rights_holder', :stored_searchable)
-    config.add_show_field solr_name('original_doi / doi', :stored_searchable)
+    config.add_show_field solr_name('original_doi', :stored_searchable)
     config.add_show_field solr_name('qualification_name', :stored_searchable)
     config.add_show_field solr_name('qualification_level', :stored_searchable)
     config.add_show_field solr_name('related_identifier', :stored_searchable)

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -519,7 +519,7 @@ module Hyrax
         #   search_field: 'all_fields'
         # @return <Hash> the inputs required for the collection member search builder
         def params_for_query
-          params.merge(q: params[:cq])
+          params.merge(q: params[:cq], search_field: 'all_fields')
         end
 
         ## NEW METHOD

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,0 +1,12 @@
+  <%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
+      <label class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
+      <div class="input-group">
+        <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
+        <div class="input-group-btn">
+          <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> <%= t('hyrax.collections.search_form.button_label') %></button>
+        </div>
+      </div>
+      <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+      <%= hidden_field_tag :search_field, params[:search_field], id: 'collection_search_field', value: 'all_fields' %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
+  <% end %>

--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,3 +1,4 @@
+  <%# OVERRIDE Hyrax 2.9.6 To insert the search_field pararmeter with a value of all_fields as a hidden input %>
   <%= form_for presenter, url: url, method: :get, class: "well form-search" do |f| %>
       <label class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">


### PR DESCRIPTION
…how_field

Fixes #170;

Add `search_field=all_fields` to collection searches, also correct a miss-referenced `original_doi` when adding to show_fields in app/controllers/catalog_controller.rb ...  it was me :( 