### PR TITLE
Re-labeling the XML parser

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -5,7 +5,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
   Bulkrax.setup do |config|
     # Add local parsers
     config.parsers += [
-        { name: " XML - ETD DC Parser", class_name: "Bulkrax::XmlEtdDcParser", partial: "xml_fields" },
+        { name: " XML - UKETD DC Parser", class_name: "Bulkrax::XmlEtdDcParser", partial: "xml_fields" },
     ]
 
     # WorkType to use as the default if none is specified in the import


### PR DESCRIPTION
From the following request.

> In dropdown list for 'Parser' in import screen, the option is 'XML - ETD DC Parser'.
>
> Please can it be amended to 'XML - UKETD_DC Parser'.
>
> Reason: Unfortunately there is a UK and US version of ETD_DC, the
> American one is ETD_DC and the British one is UKETD_DC. EThOS is very
> specifically using UKETD_DC, so please could we have the label renamed
> accordingly?

Note, we **do not** want to rename the class as that could impact existing importers's ability to properly be re-run; to rename the importer class we'd also likely need to run a data remediation script.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/268