### PR TITLE
I289

### DIFF
--- a/app/models/bulkrax/csv_entry_decorator.rb
+++ b/app/models/bulkrax/csv_entry_decorator.rb
@@ -1,19 +1,80 @@
 module Bulkrax
-  # Override Bulkrax v4.4.0
-  #
-  # @see https://github.com/samvera-labs/bulkrax/pull/719 Remove override when this PR is part of
-  #      this application's Bulkrax.
+  # Override Bulkrax v5.1.0
   module CsvEntryDecorator
-    def establish_factory_class
-      parser.model_field_mappings.each do |key|
-        add_metadata('model', record[key]) if record.key?(key)
-      end
+    # NOTE: Remove this once https://github.com/samvera-labs/bulkrax/pull/756 is merged
+    def build_object(key, value)
+      return unless hyrax_record.respond_to?(value['object'])
+
+      super(key, value)
     end
 
-    def add_ingested_metadata
-      establish_factory_class
-      super
+    # NOTE: Remove this once https://github.com/samvera-labs/bulkrax/pull/756 is merged
+    def build_value(key, value)
+      return unless hyrax_record.respond_to?(key.to_s)
+
+      super(key, value)
+    end
+
+    # Without this hack, when we export a FileSet, it skips exporting the FileSet's creator.  This
+    # is because we are overloading the `creator` in the parser.  With this change, the complex
+    # `creator` object for works will export correctly (e.g. have the constituent field parts in the
+    # CSV).  And the FileSet will have a `creator` column.
+    #
+    # @note There is almost certainly a round-trip issue remaining in that if we import the once
+    #       exported CSV, we need to account for the `creator` attribute discrepencies.  Which, at
+    #       this point may be irreconcilable unless we have an override parser for FileSets.
+    #
+    # @see https://github.com/scientist-softserv/britishlibrary/issues/289
+    def fetch_field_mapping
+      field_mappings = super
+
+      return field_mappings if importer?
+      return field_mappings unless hyrax_record.is_a?(FileSet)
+
+      field_mappings.merge("creator" => { from: "creator" })
     end
   end
 end
 Bulkrax::CsvEntry.prepend(Bulkrax::CsvEntryDecorator)
+
+# NOTE: Remove this module once https://github.com/samvera-labs/bulkrax/pull/756 is merged
+module CsvParserDecorator
+  def total
+    @total =
+      if importer?
+        importer.parser_fields['total'] || 0
+      elsif exporter?
+        limit.to_i.zero? ? current_records_for_export.count : limit.to_i
+      else
+        0
+      end
+
+    return @total
+  rescue StandardError
+    @total = 0
+  end
+
+  def write_files
+    require 'open-uri'
+    folder_count = 0
+    # TODO: This is not performant as well; unclear how to address, but lower priority as of
+    #       <2023-02-21 Tue>.
+    sorted_entries = sort_entries(importerexporter.entries.uniq(&:identifier))
+                     .select { |e| valid_entry_types.include?(e.type) }
+
+    group_size = limit.to_i.zero? ? total : limit.to_i
+    sorted_entries[0..group_size].in_groups_of(records_split_count, false) do |group|
+      folder_count += 1
+
+      CSV.open(setup_export_file(folder_count), "w", headers: export_headers, write_headers: true) do |csv|
+        group.each do |entry|
+          csv << entry.parsed_metadata
+          next if importerexporter.metadata_only? || entry.type == 'Bulkrax::CsvCollectionEntry'
+
+          store_files(entry.identifier, folder_count.to_s)
+        end
+      end
+    end
+  end
+end
+Bulkrax::CsvParser.prepend(CsvParserDecorator)

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
-
+  # rubocop:disable Metrics/BlockLength
   Bulkrax.setup do |config|
     # Add local parsers
     config.parsers += [
-        { name: " XML - UKETD DC Parser", class_name: "Bulkrax::XmlEtdDcParser", partial: "xml_fields" },
+      { name: " XML - UKETD DC Parser", class_name: "Bulkrax::XmlEtdDcParser", partial: "xml_fields" }
     ]
 
     # WorkType to use as the default if none is specified in the import
@@ -79,19 +79,19 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
       'contributor_staffmember' => { from: ['contributor_staffmember'], object: 'contributor' },
       'contributor_type' => { from: ['contributor_type'], object: 'contributor' },
       'contributor_wikidata' => { from: ['contributor_wikidata'], object: 'contributor' },
-      'creator_family_name' => { from: ['creator_family_name'], object: 'creator' },
-      'creator_given_name' => { from: ['creator_given_name'], object: 'creator' },
-      'creator_grid' => { from: ['creator_grid'], object: 'creator' },
-      'creator_institutional_relationship' => { from: ['creator_institutional_relationship'], object: 'creator', nested_type: 'Array' },
-      'creator_isni' => { from: ['creator_isni'], object: 'creator' },
-      'creator_name_type' => { from: ['creator_name_type'], object: 'creator' },
-      'creator_orcid' => { from: ['creator_orcid'], object: 'creator' },
-      'creator_organization_name' => { from: ['creator_organization_name', 'creator_organisation_name'], object: 'creator' },
-      'creator_researchassociate' => { from: ['creator_researchassociate'], object: 'creator' },
-      'creator_ror' => { from: ['creator_ror'], object: 'creator' },
-      'creator_staffmember' => { from: ['creator_staffmember'], object: 'creator' },
-      'creator_type' => { from: ['creator_type'], object: 'creator' },
-      'creator_wikidata' => { from: ['creator_wikidata'], object: 'creator' },
+      'creator_family_name' => { from: ['creator_family_name'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_given_name' => { from: ['creator_given_name'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_grid' => { from: ['creator_grid'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_institutional_relationship' => { from: ['creator_institutional_relationship'], object: 'creator', skip_object_for_model_names: ['FileSet'], nested_type: 'Array' },
+      'creator_isni' => { from: ['creator_isni'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_name_type' => { from: ['creator_name_type'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_orcid' => { from: ['creator_orcid'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_organization_name' => { from: ['creator_organization_name', 'creator_organisation_name'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_researchassociate' => { from: ['creator_researchassociate'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_ror' => { from: ['creator_ror'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_staffmember' => { from: ['creator_staffmember'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_type' => { from: ['creator_type'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_wikidata' => { from: ['creator_wikidata'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
       'current_he_institution_name' => { from: ['current_he_institution_name'], object: 'current_he_institution' },
       'date_accepted' => { from: ['date_accepted'] },
       'date_published' => { from: ['date_published_1'] },
@@ -180,50 +180,50 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
       'volume' => { from: ['volume'] }
     }
 
-    config.field_mappings['Bulkrax::CsvParser'].merge!({
+    config.field_mappings['Bulkrax::CsvParser'].merge!(
       'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true },
-      'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
-    })
+      'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true }
+    )
 
     config.field_mappings['Bulkrax::XmlEtdDcParser'] = {
-        'abstract' => { from: ['abstract'] },
-        'ethos_access_rights' => { from: ['accessRights'] },
-        'alt_title' => { from: ['alternative'] },
-        'contributor_family_name' => { from: ['advisor'], object: 'contributor' },
-        'contributor_given_name' => { from: ['advisor'], object: 'contributor' },
-        'contributor_name_type' => { from: ['advisor'], object: 'contributor' },
-        'contributor_type' => { from: ['advisor'], object: 'contributor' },
-        'contributor_position' => { from: ['advisor'], object: 'contributor' },
-        'creator_family_name' => { from: ['creator'], object: 'creator' },
-        'creator_given_name' => { from: ['creator'], object: 'creator' },
-        'creator_name_type' => { from: ['creator'], object: 'creator' },
-        'creator_position' => { from: ['creator'], object: 'creator' },
-        'creator_isni' => { from: ['authoridentifier_isni'], object: 'creator' }, # type="uketdterms:ISNI"
-        'creator_orcid' => { from: ['authoridentifier_orcid'], object: 'creator' }, # type="uketdterms:ORCID"
-        'current_he_institution_name' => { from: ['institution'], object: 'current_he_institution' },
-        'date_accepted' => { from: ['issued'] },
-        'dewey' => { from: ['subject'] }, # type="dcterms:Ddc"
-        'doi' => { from: ['identifier'] }, # type="dcterms:DOI"
-        'embargo_date' => { from: ['embargodate'] },
-        # 'embargo_date' => { from: ['dcterms:accessRights'] },
-        'funder_award' => { from: ['ugrantnumber'], object: "funder", split: /\s*;\s*/ },
-        'funder_name' => { from: ['sponsor'], object: "funder" },
-        'bulkrax_identifier' => { from: ['source'], source_identifier: true },
-        'keyword' => { from: ['coverage'], split: /\s*;\s*/ },
-        'language' => { from: ['language'] }, # type="dcterms:ISO639-2"
-        'org_unit' => { from: ['department'] },
-        'official_link' => { from: ['isReferencedBy'] },
-        'publisher' => { from: ['publisher'] },
-        'qualification_name' => { from: ['type'] },
-        'qualification_level' => { from: ['qualificationlevel'] },
-        'title' => { from: ['title'] },
-        'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true },
-        'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
-        'alternate_identifier' => {from: %w[provenance source relation], object: 'alternate_identifier' },
-        'alternate_identifier_type' => {from: %w[provenance source relation], object: 'alternate_identifier' }
-    #OAI identifier' => dcterms:provenance
-    #EThOS identifier' => dc:source
-    #Aleph system number => dc:relation
+      'abstract' => { from: ['abstract'] },
+      'ethos_access_rights' => { from: ['accessRights'] },
+      'alt_title' => { from: ['alternative'] },
+      'contributor_family_name' => { from: ['advisor'], object: 'contributor' },
+      'contributor_given_name' => { from: ['advisor'], object: 'contributor' },
+      'contributor_name_type' => { from: ['advisor'], object: 'contributor' },
+      'contributor_type' => { from: ['advisor'], object: 'contributor' },
+      'contributor_position' => { from: ['advisor'], object: 'contributor' },
+      'creator_family_name' => { from: ['creator'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_given_name' => { from: ['creator'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_name_type' => { from: ['creator'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_position' => { from: ['creator'], object: 'creator', skip_object_for_model_names: ['FileSet'] },
+      'creator_isni' => { from: ['authoridentifier_isni'], object: 'creator', skip_object_for_model_names: ['FileSet'] }, # type="uketdterms:ISNI"
+      'creator_orcid' => { from: ['authoridentifier_orcid'], object: 'creator', skip_object_for_model_names: ['FileSet'] }, # type="uketdterms:ORCID"
+      'current_he_institution_name' => { from: ['institution'], object: 'current_he_institution' },
+      'date_accepted' => { from: ['issued'] },
+      'dewey' => { from: ['subject'] }, # type="dcterms:Ddc"
+      'doi' => { from: ['identifier'] }, # type="dcterms:DOI"
+      'embargo_date' => { from: ['embargodate'] },
+      # 'embargo_date' => { from: ['dcterms:accessRights'] },
+      'funder_award' => { from: ['ugrantnumber'], object: "funder", split: /\s*;\s*/ },
+      'funder_name' => { from: ['sponsor'], object: "funder" },
+      'bulkrax_identifier' => { from: ['source'], source_identifier: true },
+      'keyword' => { from: ['coverage'], split: /\s*;\s*/ },
+      'language' => { from: ['language'] }, # type="dcterms:ISO639-2"
+      'org_unit' => { from: ['department'] },
+      'official_link' => { from: ['isReferencedBy'] },
+      'publisher' => { from: ['publisher'] },
+      'qualification_name' => { from: ['type'] },
+      'qualification_level' => { from: ['qualificationlevel'] },
+      'title' => { from: ['title'] },
+      'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true },
+      'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true },
+      'alternate_identifier' => { from: %w[provenance source relation], object: 'alternate_identifier' },
+      'alternate_identifier_type' => { from: %w[provenance source relation], object: 'alternate_identifier' }
+      #OAI identifier' => dcterms:provenance
+      #EThOS identifier' => dc:source
+      #Aleph system number => dc:relation
     }
     # Add to, or change existing mappings as follows
     #   e.g. to exclude date
@@ -236,4 +236,5 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
     # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
     # config.reserved_properties += ['my_field']
   end
+  # rubocop:enable Metrics/BlockLength
 end


### PR DESCRIPTION
## Ignore `creator` object for FileSet import

9acbfead170d33cd854d91c0f53c27b4dfd1bfab

In the British Library code-base there are two declarations of
`creator`:

1. For FileSet the creator is an array of literals (e.g. "Jeremy Friesen")
2. For works the creator is an array of complex objects (e.g. [{ given_name:
   "Jeremy", family_name: "Friesen" }])

This creates issues when we use the same parser fields for FileSet and
non-FileSet; namely we attempt to cast the FileSet creator into a
complex object.  Which fails.

With this commit I'm doing two things:

1. Appeasing rubocop
2. Declaring the FileSet's creator as a non-object field

In declaring FileSet's creator as a non-object field, we avoid the
serialization.

As I think more on this, I would ideally like to have different parsers
for FileSets.  However, I think this will be difficult as we use the
parser to sniff out the object's "factory_class".

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/issues/754
- https://github.com/samvera-labs/bulkrax/issues/747

## Handle creator export disparity for FileSet and works

d79ab82ae670c4e68b395588f36960157482223f

This commit includes two primary things:

- CsvParser fix to logic (see https://github.com/samvera-labs/bulkrax/pull/756)
- CsvEntry fix for creator property disparity between FileSets and other works

Without this hack, when we export a FileSet, it skips exporting the
FileSet's creator.  This is because we are overloading the `creator` in
the parser.  With this change, the complex `creator` object for works
will export correctly (e.g. have the constituent field parts in the
CSV).  And the FileSet will have a `creator` column.

Related to:

- #289
- https://github.com/samvera-labs/bulkrax/pull/756
