### PR TITLE
Bumping nesting indexer to v0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,5 +150,5 @@ gem "sentry-raven"
 gem 'sidekiq'
 gem 'tether-rails'
 gem 'validate_url'
-gem 'hyrax-v2_graph_indexer'
+gem 'hyrax-v2_graph_indexer', "~> 0.3", git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer.git', ref: 'e8b5976c6aa91ac18af8b29acb949e8f30152c2d'
 gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'ced827e19e7f20314bdce11269ce201784b8e053'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,15 @@ GIT
       dry-equalizer
 
 GIT
+  remote: https://github.com/scientist-softserv/hyrax-v2_graph_indexer.git
+  revision: e8b5976c6aa91ac18af8b29acb949e8f30152c2d
+  ref: e8b5976c6aa91ac18af8b29acb949e8f30152c2d
+  specs:
+    hyrax-v2_graph_indexer (0.3.0)
+      hyrax (~> 2.9)
+      railties
+
+GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
   revision: ced827e19e7f20314bdce11269ce201784b8e053
   ref: ced827e19e7f20314bdce11269ce201784b8e053
@@ -606,9 +615,6 @@ GEM
       signet
       solrizer (>= 3.4, < 5)
       tinymce-rails (~> 4.1)
-    hyrax-v2_graph_indexer (0.1.0)
-      hyrax (~> 2.9)
-      railties
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
@@ -1262,7 +1268,7 @@ DEPENDENCIES
   hyrax (~> 2.9, >= 2.9.1)
   hyrax-doi!
   hyrax-iiif_av!
-  hyrax-v2_graph_indexer
+  hyrax-v2_graph_indexer (~> 0.3)!
   i18n-debug
   i18n-tasks
   iiif_print (~> 1.0)!


### PR DESCRIPTION
This resolves a bug found in the tests:

```shell

2) FeaturedCollectionList featured_collections when one of the files is
   deleted is a list of the remaining featured collection objects, each
   with the collection's solr_doc

Failure/Error: collection1.destroy

NoMethodError:

  undefined method `each' for true:TrueClass

/usr/local/bundle/gems/hyrax-2.9.6/app/models/concerns/hyrax/collection_nesting.rb:35:in `update_child_nested_collection_relationship_indices'
/usr/local/bundle/gems/active-fedora-12.2.3/lib/active_fedora/callbacks.rb:231:in `destroy'
./spec/models/featured_collection_list_spec.rb:28:in `block (4 levels) in <top (required)>'
```
