### PR TITLE
Bumping Bulkrax to remove export of works as file sets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 
 # Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have
 #            a quick scan of what version we're assuming/working with.
-gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: 'e7d58e6171173d30cf4b6272c124078936882e37'
+gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '4a04f8b9b19af78f75d286dd2d78516fe4cf474e'
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: e7d58e6171173d30cf4b6272c124078936882e37
-  ref: e7d58e6171173d30cf4b6272c124078936882e37
+  revision: 4a04f8b9b19af78f75d286dd2d78516fe4cf474e
+  ref: 4a04f8b9b19af78f75d286dd2d78516fe4cf474e
   specs:
     bulkrax (5.1.0)
       bagit (~> 0.4)


### PR DESCRIPTION
With this commit we're incorporating changes that resolves the accidental export of works as file sets.

See the following for further context:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/pull/749
- https://github.com/samvera-labs/bulkrax/pull/759
