### PR TITLE
Remove child works from recent works

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 89f08345bc3800a56f7ad7d9f774ebaa48e3726c
+  revision: ec8da2e7bb144b9daaaaf0770174f47f00f96fb8
   branch: main
   specs:
     iiif_print (1.0.0)

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "iiif_print/homepage_search_builder"
 
 # OVERRIDE: Hyrax v2.9.0

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "iiif_print/homepage_search_builder"
 
 # OVERRIDE: Hyrax v2.9.0
 # - add home_text content block to the index method - Adding themes
@@ -21,7 +22,7 @@ module Hyrax
     # The search builder for finding recent documents
     # Override of Blacklight::RequestBuilders
     def search_builder_class
-      Hyrax::HomepageSearchBuilder
+      IiifPrint::HomepageSearchBuilder
     end
 
     class_attribute :presenter_class


### PR DESCRIPTION
Modify homepage search for recent works by updating iiif_print and using new homepage search builder.

Ref https://github.com/scientist-softserv/iiif_print/issues/187 and https://github.com/scientist-softserv/britishlibrary/issues/303

# Expected Behavior Before Changes
Homepage includes child works in recent works list.

# Expected Behavior After Changes
Homepage shows only parent works in recent works list.

<details>
<summary> Screenshots</summary>

**Before**
![Screenshot 2023-03-15 at 6 27 32 PM](https://user-images.githubusercontent.com/17851674/226222773-eb3aeb4d-8a4b-4ca2-9d62-d8939d574727.png)

**After**
![Screenshot 2023-03-17 at 5 47 58 PM](https://user-images.githubusercontent.com/17851674/226222716-ee621fe8-79fc-4216-ac65-3d97ea6db9db.png)
</details>
