### PR TITLE
i234 - deactivate controlled vocab

### DIFF
--- a/config/authorities/institution.yml
+++ b/config/authorities/institution.yml
@@ -21,28 +21,28 @@ terms:
     active: true
   - id: Tate
     term: Tate
-    active: true
+    active: false
   - id: Barts Health NHS Trust
     term: Barts Health NHS Trust
-    active: true
+    active: false
   - id: Black Country Health Libraries Consortium
     term: Black Country Health Libraries Consortium
-    active: true
+    active: false
   - id: Birmingham and Solihull Mental Health NHS Foundation Trust
     term: Birmingham and Solihull Mental Health NHS Foundation Trust
-    active: true
+    active: false
   - id: Gloucestershire Hospitals NHS Foundation Trust
     term: Gloucestershire Hospitals NHS Foundation Trust
-    active: true
+    active: false
   - id: Norfolk and Waveney Strategic Transformation Partnership
     term: Norfolk and Waveney Strategic Transformation Partnershipm
     active: false
   - id: Norfolk and Waveney Integrated Care System
     term: Norfolk and Waveney Integrated Care System
-    active: true
+    active: false
   - id: Somerset NHS Foundation Trust
     term: Somerset NHS Foundation Trust
-    active: true
+    active: false
   - id: National Trust
     term: National Trust
     active: true


### PR DESCRIPTION
This MR deactivates controlled vocabulary per https://github.com/scientist-softserv/britishlibrary/issues/234

# Story

A user should no longer be able to select the following options from the Institution dropdown, when creating or editing a work. 

- [ ]  1. Tate
- [ ] 2. Barts Health NHS Trust
- [ ] 3. Black Country Health Libraries Consortium
- [ ] 4. Birmingham and Solihull Mental Health NHS Foundation Trust
- [ ] 5. Gloucestershire Hospitals NHS Foundation Trust
- [ ] 6. Norfolk and Waveney Integrated Care System
- [ ] 7. Somerset NHS Foundation Trust

Refs https://github.com/scientist-softserv/britishlibrary/issues/234

# Expected Behavior Before Changes

Options are available
<img width="830" alt="Screenshot 2023-03-20 at 10 55 58 AM" src="https://user-images.githubusercontent.com/10081604/226428176-a6cd9d78-8799-4a92-bbf7-f0219f8a05d9.png">



# Expected Behavior After Changes
Options are deactivated and no longer appear in the list

<img width="490" alt="Screenshot 2023-03-20 at 11 00 28 AM" src="https://user-images.githubusercontent.com/10081604/226428237-56d712d4-6407-4e01-ace0-338608ab9a49.png">


# Notes