### PR TITLE
179 xml tag handling

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -45,7 +45,7 @@ module Hyku
     def date_accepted
       date = solr_document["date_accepted_dtsim"]
       return formatted_date(date) if date.present?
-      solr_document["date_accepted_tesim"].map { |d| d.to_date.strftime("%Y") }
+      solr_document["date_accepted_tesim"].map { |d| d.to_date.strftime("%Y") } if solr_document["date_accepted_tesim"] 
     end
 
     def date_submitted

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -45,7 +45,8 @@ module Hyku
     def date_accepted
       date = solr_document["date_accepted_dtsim"]
       return formatted_date(date) if date.present?
-      solr_document["date_accepted_tesim"].map { |d| d.to_date.strftime("%Y") } if solr_document["date_accepted_tesim"] 
+      return if solr_document["date_accepted_tesim"].blank?
+      solr_document["date_accepted_tesim"].map { |d| d.to_date.strftime("%Y") }
     end
 
     def date_submitted

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -45,7 +45,7 @@ module Hyku
     def date_accepted
       date = solr_document["date_accepted_dtsim"]
       return formatted_date(date) if date.present?
-      solr_document["date_accepted_tesim"]
+      solr_document["date_accepted_tesim"].map { |d| d.to_date.strftime("%Y") }
     end
 
     def date_submitted

--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -17,13 +17,14 @@ module Ubiquity
 
     def self.return_date_part(date, date_part)
       return nil if date.blank?
-      date = date.to_date 
+
+      date = date.to_date
       if date_part == 'year'
-        date.strftime("%Y") if date.respond_to?(:strftime)
+        date.strftime("%Y")
       elsif date_part == 'month'
-        date.strftime("%m") if date.respond_to?(:strftime)
+        date.strftime("%m")
       elsif date_part == 'day'
-        date.strftime("%d") if date.respond_to?(:strftime)
+        date.strftime("%d")
       end
     end
 

--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -17,16 +17,13 @@ module Ubiquity
 
     def self.return_date_part(date, date_part)
       return nil if date.blank?
-      split_date = date.split('-') if date.respond_to?(:split)
+      date = date.to_date 
       if date_part == 'year'
-        return date.strftime("%Y") if date.respond_to?(:strftime)
-        split_date[0]
+        date.strftime("%Y") if date.respond_to?(:strftime)
       elsif date_part == 'month'
-        return date.strftime("%m") if date.respond_to?(:strftime)
-        split_date[1] if split_date.length > 1
+        date.strftime("%m") if date.respond_to?(:strftime)
       elsif date_part == 'day'
-        return date.strftime("%d") if date.respond_to?(:strftime)
-        split_date[2] if split_date.length == 3
+        date.strftime("%d") if date.respond_to?(:strftime)
       end
     end
 


### PR DESCRIPTION
# Story

When I XML import an issue date, its year should appear as date accepted on the work's show page. 

This field should also be editable. 

Refs https://github.com/scientist-softserv/britishlibrary/issues/179
# Expected Behavior Before Changes

Before, the year would should up as 01/01/2016 (for example)

# Expected Behavior After Changes

Now, only the year should be displayed. 


# Screenshots / Video
![Screenshot 2023-03-20 at 12 30 06 PM](https://user-images.githubusercontent.com/10081604/226447419-14e5d2d7-b651-465f-b649-6a6c1ef9ed44.png)

![Screenshot 2023-03-20 at 12 30 23 PM](https://user-images.githubusercontent.com/10081604/226447438-fc3c5d90-6e95-499b-9926-50ad2e43f045.png)




# Notes