### PR TITLE
I270 xml qualification handling for phd

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -7,15 +7,19 @@ module Bulkrax::HasLocalProcessing
   def add_local
     parsed_metadata['resource_type'] = ['ThesisOrDissertation Doctoral thesis'] if parser.is_a? Bulkrax::XmlEtdDcParser
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
-    parsed_metadata["qualification_name"] = if parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.', '').include?('phd')
-                                              'PhD'
-                                            else
-                                              parsed_metadata['qualification_name']
-                                            end
+    parsed_metadata["qualification_name"] = set_qualification_name if parsed_metadata["qualification_name"] 
     set_institutional_relationships
 
     ['funder', 'creator', 'contributor', 'editor', 'alternate_identifier', 'related_identifier', 'current_he_institution'].each do |key|
       parsed_metadata[key] = [parsed_metadata[key].to_json] if parsed_metadata[key].present?
+    end
+  end
+
+  def set_qualification_name
+    if parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.', '').include?('phd')
+      'PhD'
+    else
+      parsed_metadata['qualification_name']
     end
   end
 

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -5,6 +5,7 @@ module Bulkrax::HasLocalProcessing
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data
   def add_local
+    parsed_metadata['resource_type'] = ['ThesisOrDissertation Doctoral thesis'] if parser.is_a? Bulkrax::XmlEtdDcParser
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
     parsed_metadata["qualification_name"] = if parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.', '').include?('phd')
                                               'PhD'

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,6 +6,8 @@ module Bulkrax::HasLocalProcessing
   # to add a custom property from outside of the import data
   def add_local
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
+    parsed_metadata["qualification_name"] = parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.
+      ', '').include?('phd') ? 'PhD' : parsed_metadata['qualification_name']
     set_institutional_relationships
 
     ['funder', 'creator', 'contributor', 'editor', 'alternate_identifier', 'related_identifier', 'current_he_institution'].each do |key|

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,8 +6,11 @@ module Bulkrax::HasLocalProcessing
   # to add a custom property from outside of the import data
   def add_local
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
-    parsed_metadata["qualification_name"] = parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.
-      ', '').include?('phd') ? 'PhD' : parsed_metadata['qualification_name']
+    parsed_metadata["qualification_name"] = if parsed_metadata['qualification_name'].gsub(/\s+/, "").downcase.tr('.', '').include?('phd')
+                                              'PhD'
+                                            else
+                                              parsed_metadata['qualification_name']
+                                            end
     set_institutional_relationships
 
     ['funder', 'creator', 'contributor', 'editor', 'alternate_identifier', 'related_identifier', 'current_he_institution'].each do |key|

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -7,7 +7,7 @@ module Bulkrax::HasLocalProcessing
   def add_local
     parsed_metadata['resource_type'] = ['ThesisOrDissertation Doctoral thesis'] if parser.is_a? Bulkrax::XmlEtdDcParser
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
-    parsed_metadata["qualification_name"] = set_qualification_name if parsed_metadata["qualification_name"] 
+    parsed_metadata["qualification_name"] = set_qualification_name if parsed_metadata["qualification_name"]
     set_institutional_relationships
 
     ['funder', 'creator', 'contributor', 'editor', 'alternate_identifier', 'related_identifier', 'current_he_institution'].each do |key|


### PR DESCRIPTION
Ref #270, [#269](https://github.com/scientist-softserv/britishlibrary/issues/269)

Prior to this change the PhD qualification was parsed as Ph.D. upon XML importing.

With this change the qualification was set to be parsed as "PhD."

Additionally, resource type will be set for UKETD_DC parser.