### PR TITLE
Update iiif_print gem to fix ordered members

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: ec8da2e7bb144b9daaaaf0770174f47f00f96fb8
+  revision: e3384284a9992df867b7bedc256c82485355551d
   branch: main
   specs:
     iiif_print (1.0.0)


### PR DESCRIPTION
# Story

Sorting of child works split from a PDF was not handling page numbers correctly. This PR brings in the [iiif_print fix.](https://github.com/scientist-softserv/iiif_print/pull/197)

Refs https://github.com/scientist-softserv/britishlibrary/issues/339.

# Expected Behavior Before Changes

If a PDF has more than 9 pages, the child works will not be sequenced correctly.

# Expected Behavior After Changes

Page numbers are padded to sequence the child works correctly.

# Screenshots / Video

<details>
<summary>Before & After Screenshots</summary>

Before:
![Screenshot 2023-03-21 at 5 41 25 PM](https://user-images.githubusercontent.com/17851674/226972467-300d0f33-f720-4b25-882b-97dbe42cfd25.png)

After:
![Screenshot 2023-03-21 at 5 40 55 PM](https://user-images.githubusercontent.com/17851674/226972503-847b6951-e1ca-48a8-a5e5-009f8e855a61.png)

</details>

# Notes