### PR TITLE
Add property :record_level_file_version_declaration

### DIFF
--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -85,7 +85,9 @@ module Ubiquity
                                                                  current_he_institution_isni
                                                                  current_he_institution_ror] }
 
-            permitted_params << :doi_options
+          permitted_params << :doi_options
+
+          permitted_params << :record_level_file_version_declaration
         end
       end
     end # closes class class_methods

--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -54,6 +54,7 @@ module Ubiquity
 
     class_methods do
 
+      # rubocop:disable Metrics/MethodLength
       def build_permitted_params
         super.tap do |permitted_params|
           permitted_params << {contributor_group: [:contributor_organization_name, :contributor_given_name,
@@ -91,6 +92,7 @@ module Ubiquity
         end
       end
     end # closes class class_methods
+    # rubocop:enable Metrics/MethodLength
 
     # instance methods
     def title

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,6 +21,12 @@ class Article < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  # Added the property record_level_file_version_declaration
+  # see https://github.com/scientist-softserv/britishlibrary/issues/330
+  property :record_level_file_version_declaration, predicate: ::RDF::Vocab::BF2.UsageAndAccessPolicy, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -20,6 +20,12 @@ class ConferenceItem < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  # Added the property record_level_file_version_declaration
+  # see https://github.com/scientist-softserv/britishlibrary/issues/330
+  property :record_level_file_version_declaration, predicate: ::RDF::Vocab::BF2.UsageAndAccessPolicy, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -22,6 +22,12 @@ class GenericWork < ActiveFedora::Base
 
   self.indexer = GenericWorkIndexer
 
+  # Added the property record_level_file_version_declaration
+  # see https://github.com/scientist-softserv/britishlibrary/issues/330
+  property :record_level_file_version_declaration, predicate: ::RDF::Vocab::BF2.UsageAndAccessPolicy, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include Hyrax::BasicMetadata

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -86,6 +86,7 @@ class SolrDocument
   attribute :collection_names, Solr::Array, solr_name('collection_names')
   attribute :collection_id, Solr::Array, solr_name('collection_id')
   attribute :ethos_access_rights, Solr::Array, solr_name('ethos_access_rights')
+  attribute :record_level_file_version_declaration, Solr::String, solr_name('record_level_file_version_declaration')
 
   field_semantics.merge!(
     contributor: ['contributor_list_tesim', 'editor_list_tesim', 'funder_tesim'],

--- a/app/views/hyrax/base/_form_declaration.html.erb
+++ b/app/views/hyrax/base/_form_declaration.html.erb
@@ -1,0 +1,4 @@
+<% if curation_concern.respond_to?(:record_level_file_version_declaration) %>
+  <% checked = true if curation_concern.record_level_file_version_declaration %>
+  <%= f.input :record_level_file_version_declaration, as: :boolean, label: t('hyrax.base.form_files.record_level_file_version_declaration_question', model: curation_concern.class), input_html: { checked: checked } %>
+<% end %>

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -1,4 +1,5 @@
-<!-- OVERRIDE Hyrax 2.9 to get browse everything working properyl -->
+<!-- OVERRIDE Hyrax 2.9 to get browse everything working properly
+     and to add render form_declaration -->
 <div id="fileupload">
    <!-- Redirect browsers with JavaScript disabled to the origin page -->
    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
@@ -9,6 +10,9 @@
    <% else %>
      <%= t('hyrax.base.form_files.local_upload_html') %>
    <% end %>
+
+   <%= render partial: 'form_declaration', locals: { f: f, curation_concern: curation_concern } %>
+
    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
    <div class="fileupload-buttonbar">
      <div class="row">

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -153,6 +153,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
       'publisher' => { from: ['publisher'] },
       'qualification_level' => { from: ['qualification_level'] },
       'qualification_name' => { from: ['qualification_name'] },
+      'record_level_file_version_declaration' => { from: 'file_declaration' },
       'refereed' => { from: ['peer_reviewed'] },
       'related_exhibition' => { from: ['related_exhibition'] },
       'related_exhibition_date' => { from: ['related_exhibition_date'] },

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -326,6 +326,7 @@ en:
           accommodate your request. If you experience errors uploading from the
           cloud, let us know via the %{contact_href}.</p>
         local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
+        record_level_file_version_declaration_question: Does %{model} include non-restricted use file?
       form_member_of_collections:
         actions:
           remove: Remove from collection


### PR DESCRIPTION
# Story

In order to fulfill Plan S requirements, a new property is needed on work types which may be peer-reviewed. Add record_level_file_version_declaration question & checkbox to models Article, Conference Item, and Generic Work.

The client suggested that this checkbox be added to the files tab if possible.

Refs https://github.com/scientist-softserv/britishlibrary/issues/330

# Expected Behavior After Changes

- [ ]  Models Article, Conference Item and Generic Work have new question & checkbox added
- [ ]  Value can be added both in UI and via Bulkrax import
- [ ]  Value is optional, and works save with or without it checked
- [ ]  Value can be edited and re-saved from the files tab when editing a work
 
# Screenshots / Video

<details>
<summary>Screenshots</summary>

**Checkbox option is available for work types Article, Conference Item, and Generic Work**
![Screenshot 2023-03-24 at 11 42 07 AM](https://user-images.githubusercontent.com/17851674/227652964-a33f89f6-ae81-4585-bb17-e999441461ac.png)

**Checkbox is not available for other work types**
![Screenshot 2023-03-24 at 11 39 20 AM](https://user-images.githubusercontent.com/17851674/227652970-f34197c7-6a2f-4416-9a7c-3677df46085d.png)

**Editing a work pre-loads the current value and allows update**
![Screenshot 2023-03-24 at 6 08 40 PM](https://user-images.githubusercontent.com/17851674/227652953-d7ee4f3e-0bbb-4501-8ccb-bc068c274d98.png)

</details>

# Notes
CSV file for import should have column `file_declaration` with a value of `1` on the work to set the flag.

Text of the question on the checkbox may be changed via `hyrax.base.form_files.record_level_file_version_declaration_question` in `hyrax.en.yml`. Translations to other languages are still needed in the remaining translation yml files.