### PR TITLE
[i179] - date parsing

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -43,9 +43,9 @@ module Hyku
     end
 
     def date_accepted
-      date = solr_document["date_accepted_dtsim"]
-      return formatted_date(date) if date.present?
-      solr_document["date_accepted_tesim"]
+      return if solr_document["date_accepted_tesim"]&.join.blank?
+
+      solr_document["date_accepted_tesim"].map { |d| Ubiquity::ParseDate.return_date_part(d, "year") }
     end
 
     def date_submitted

--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -20,7 +20,7 @@ module Ubiquity
       return date if date_part == 'year' && date.match(/^\d{4}$/)
 
       begin
-        parsed_date = date.match(%r{\d{1,2}/\d{1,2}/\d{4}}) ? Date.strptime(date, '%m/%d/%Y') : Date.parse(date)
+        parsed_date = date =~ %r{\d{1,2}/\d{1,2}/\d{4}} ? Date.strptime(date, '%m/%d/%Y') : Date.parse(date)
       rescue ArgumentError
         parsed_date = nil
       end
@@ -31,7 +31,6 @@ module Ubiquity
       when 'year'  then parsed_date.strftime("%Y")
       when 'month' then parsed_date.strftime("%m")
       when 'day'   then parsed_date.strftime("%d")
-      else nil
       end
     end
 

--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -17,16 +17,21 @@ module Ubiquity
 
     def self.return_date_part(date, date_part)
       return nil if date.blank?
-      split_date = date.split('-') if date.respond_to?(:split)
-      if date_part == 'year'
-        return date.strftime("%Y") if date.respond_to?(:strftime)
-        split_date[0]
-      elsif date_part == 'month'
-        return date.strftime("%m") if date.respond_to?(:strftime)
-        split_date[1] if split_date.length > 1
-      elsif date_part == 'day'
-        return date.strftime("%d") if date.respond_to?(:strftime)
-        split_date[2] if split_date.length == 3
+      return date if date_part == 'year' && date.match(/^\d{4}$/)
+
+      begin
+        parsed_date = date.match(%r{\d{1,2}/\d{1,2}/\d{4}}) ? Date.strptime(date, '%m/%d/%Y') : Date.parse(date)
+      rescue ArgumentError
+        parsed_date = nil
+      end
+
+      return nil if parsed_date.nil?
+
+      case date_part
+      when 'year'  then parsed_date.strftime("%Y")
+      when 'month' then parsed_date.strftime("%m")
+      when 'day'   then parsed_date.strftime("%d")
+      else nil
       end
     end
 

--- a/spec/presenters/hyku/work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/work_show_presenter_spec.rb
@@ -121,4 +121,38 @@ RSpec.describe Hyku::WorkShowPresenter do
       end
     end
   end
+
+  describe "#date_accepted" do
+    context "when date_accepted is in YYYY format" do
+      let(:document) { { "date_accepted_tesim" => ["2023"] } }
+
+      it "returns the formatted date" do
+        expect(presenter.date_accepted).to eq(["2023"])
+      end
+    end
+
+    context "when date_accepted is in YYYY-MM-DD format" do
+      let(:document) { { "date_accepted_tesim" => ["2023-12-13"] } }
+
+      it "returns the formatted date" do
+        expect(presenter.date_accepted).to eq(["2023"])
+      end
+    end
+
+    context "when date_accepted is in MM/DD/YYYY format" do
+      let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+
+      it "returns the formatted date" do
+        expect(presenter.date_accepted).to eq(["2023"])
+      end
+    end
+
+    context "when date_accepted is not valid" do
+      let(:document) { { "date_accepted_tesim" => [""] } }
+
+      it "returns nil" do
+        expect(presenter.date_accepted).to be nil
+      end
+    end
+  end
 end

--- a/spec/services/ubiquity/parse_date_spec.rb
+++ b/spec/services/ubiquity/parse_date_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Ubiquity::ParseDate do
+  describe '.return_date_part' do
+    it 'handles YYYY-MM-DD format' do
+      date = '2023-12-13'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to eq('12')
+      expect(described_class.return_date_part(date, 'day')).to eq('13')
+    end
+
+    it 'handles MM/DD/YYYY format' do
+      date = '12/13/2023'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to eq('12')
+      expect(described_class.return_date_part(date, 'day')).to eq('13')
+    end
+
+    it 'handles YYYY format' do
+      date = '2023'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to be_nil
+      expect(described_class.return_date_part(date, 'day')).to be_nil
+    end
+
+    it 'handles full month names' do
+      date = 'December 13, 2023'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to eq('12')
+      expect(described_class.return_date_part(date, 'day')).to eq('13')
+    end
+
+    it 'returns nil for invalid dates' do
+      date = 'invalid_date'
+      expect(described_class.return_date_part(date, 'year')).to be_nil
+      expect(described_class.return_date_part(date, 'month')).to be_nil
+      expect(described_class.return_date_part(date, 'day')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
[Adjust parse date logic](https://github.com/scientist-softserv/britishlibrary/commit/930ebcda9971949ef7c902ee97a94283ad6b441e) 

This commit will account for more varied forms of dates as outlined in
the spec.

Formats:
- YYYY-MM-DD
- MM/DD/YYYY
- YYYY
- Date parsable strings
- invalid

---

[Modify date accepted logic](https://github.com/scientist-softserv/britishlibrary/commit/02e9166db77940af2c9bc27bbe998ec95c8a5fa1) 

Added an additional guard so [""] doesn't throw an error.  This occurs
usually with Bulkrax CSV imports when an entry has a header but no value
in the field.  Also the #formatted_date method doesn't exist anywhere so
it was removed.  The only unknown is if "date_published_dtsim" is ever a
case vs "date_published_tesim".  In any case, in the old logic, if we
had "date_published_dtsim" then we would have gotten a NoMethodError.