### PR TITLE
i357 - Speed up tesseract in deployed environment

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -160,6 +160,8 @@ extraEnvVars: &envVars
     value: $SECRET_KEY_BASE
   - name: SENTRY_DSN
     value: https://bcbcbdd237984028a7d0b76d96ba90dd@o1008683.ingest.sentry.io/6745017
+  - name: OMP_THREAD_LIMIT
+    value: "1"
 
 worker:
   replicaCount: 1

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -158,6 +158,8 @@ extraEnvVars: &envVars
     value: $SECRET_KEY_BASE
   - name: SENTRY_DSN
     value: https://bcbcbdd237984028a7d0b76d96ba90dd@o1008683.ingest.sentry.io/6745017
+  - name: OMP_THREAD_LIMIT
+    value: "1"
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
ref: #357 

Setting `OMP_THREAD_LIMIT` to one will speed up tesseract processing.
