### PR TITLE
Add Open Access status to feed

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -27,6 +27,7 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc['year_published_isi'] = object.date_published[0...4].to_i if object.date_published.present?
       solr_doc[Solrizer.solr_name('account_cname')] = Site.instance&.account&.cname
       solr_doc['account_institution_name_ssim'] = "#{Site.instance.institution_name} Research Repository"
+      solr_doc['open_access_determination_ssim'] = object.open_access_determination
     end
   end
 end

--- a/app/models/concerns/ubiquity/universal_metadata.rb
+++ b/app/models/concerns/ubiquity/universal_metadata.rb
@@ -151,7 +151,7 @@ module Ubiquity
     end
     # rubocop:enable Metrics/MethodLength
 
-    OPEN_ACCESS_RIGHTS = 'info:eu-repo/semantics/openAccess'
+    OPEN_ACCESS_RIGHTS = 'info:eu-repo/semantics/openAccess'.freeze
     def open_access_determination
       return OPEN_ACCESS_RIGHTS if OpenAccessService.new(work: self).unrestricted_use_files?
       nil

--- a/app/models/concerns/ubiquity/universal_metadata.rb
+++ b/app/models/concerns/ubiquity/universal_metadata.rb
@@ -151,5 +151,8 @@ module Ubiquity
     end
     # rubocop:enable Metrics/MethodLength
 
+    def open_access_determination
+      OpenAccessService.unrestricted_use_files_for?(work: self)
+    end
   end
 end

--- a/app/models/concerns/ubiquity/universal_metadata.rb
+++ b/app/models/concerns/ubiquity/universal_metadata.rb
@@ -151,8 +151,10 @@ module Ubiquity
     end
     # rubocop:enable Metrics/MethodLength
 
+    OPEN_ACCESS_RIGHTS = 'info:eu-repo/semantics/openAccess'
     def open_access_determination
-      OpenAccessService.unrestricted_use_files_for?(work: self)
+      return OPEN_ACCESS_RIGHTS if OpenAccessService.new(work: self).unrestricted_use_files?
+      nil
     end
   end
 end

--- a/app/models/plan_s_funder.rb
+++ b/app/models/plan_s_funder.rb
@@ -1,0 +1,3 @@
+class PlanSFunder < ApplicationRecord
+  validates_uniqueness_of :funder_doi
+end

--- a/app/models/plan_s_funder.rb
+++ b/app/models/plan_s_funder.rb
@@ -1,3 +1,3 @@
 class PlanSFunder < ApplicationRecord
-  validates_uniqueness_of :funder_doi
+  validates :funder_doi, uniqueness: true
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -87,7 +87,7 @@ class SolrDocument
   attribute :collection_id, Solr::Array, solr_name('collection_id')
   attribute :ethos_access_rights, Solr::Array, solr_name('ethos_access_rights')
   attribute :record_level_file_version_declaration, Solr::String, solr_name('record_level_file_version_declaration')
-  attribute :open_access_determination, Solr::String, solr_name('open_access') 
+  attribute :open_access_determination, Solr::String, 'open_access_determination_ssim'
 
   field_semantics.merge!(
     contributor: ['contributor_list_tesim', 'editor_list_tesim', 'funder_tesim'],
@@ -98,7 +98,7 @@ class SolrDocument
     language: 'language_tesim',
     publisher: 'publisher_tesim',
     relation: 'journal_title_tesim',
-    rights: 'license_tesim',
+    rights: ['license_tesim', 'open_access_determination_ssim'],
     subject: 'keyword_tesim',
     title: 'title_tesim',
     type: 'human_readable_type_tesim'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -87,6 +87,7 @@ class SolrDocument
   attribute :collection_id, Solr::Array, solr_name('collection_id')
   attribute :ethos_access_rights, Solr::Array, solr_name('ethos_access_rights')
   attribute :record_level_file_version_declaration, Solr::String, solr_name('record_level_file_version_declaration')
+  attribute :open_access_determination, Solr::String, solr_name('open_access') 
 
   field_semantics.merge!(
     contributor: ['contributor_list_tesim', 'editor_list_tesim', 'funder_tesim'],

--- a/app/services/maintain_plan_s_funders.rb
+++ b/app/services/maintain_plan_s_funders.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class MaintainPlanSFunders
+  ##
+  # Responsible for initial loading & maintenance of PlanSFunder model data.
+  def self.call(csv_path: "lib/data/plan_s_funders.csv")
+    @doi_in_csv = []
+    @funders_to_reindex = []
+    csv_data = File.read(csv_path)
+    CSV.parse(csv_data, headers: true) do |row|
+      convert_to_funder(row: row)
+    end
+    # This is preparation for using API calls... funders may be removed
+    # rather than just deactivated as we are doing in CSV
+    handle_removed_funders
+    # @TODO: Process list of funder DOIs to reindex in the rake task (this is not happening yet).
+    @funders_to_reindex
+  end
+
+  def self.convert_to_funder(row:)
+    record_data = row.to_hash.symbolize_keys
+    maintain_record(data: record_data)
+  end
+  private_class_method :convert_to_funder
+
+  def self.handle_removed_funders
+    PlanSFunder.where.not(funder_doi: @doi_in_csv).each do |funder|
+      funder.update(funder_status: 'inactive')
+      need_to_reindex(funder: funder)
+    end
+  end
+  private_class_method :handle_removed_funders
+
+  def self.maintain_record(data:)
+    @doi_in_csv << data[:funder_doi]
+
+    # Update record based on this row
+    funder = find_or_initialize_funder(data: data)
+
+    if funder.new_record? ||
+       funder.funder_status != data[:funder_status] ||
+       funder.funder_name != data[:funder_name]
+
+      funder.funder_status = data[:funder_status]
+      funder.funder_name = data[:funder_name]
+      funder.save
+      need_to_reindex(funder: funder)
+    end
+
+    true
+  end
+  private_class_method :maintain_record
+
+  def self.find_or_initialize_funder(data:)
+    PlanSFunder.find_or_initialize_by(funder_doi: data[:funder_doi]) do |funder|
+      funder.funder_name = data[:funder_name]
+      funder.funder_status = data[:funder_status]
+    end
+  end
+  private_class_method :find_or_initialize_funder
+
+  def self.need_to_reindex(funder:)
+    @funders_to_reindex << funder.funder_doi
+  end
+  private_class_method :need_to_reindex
+end

--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -1,80 +1,83 @@
 class OpenAccessService
   def self.unrestricted_use_files_for?(work:)
     case work
+
     # Scholarly articles
-    when Article || ConferenceItem || GenericWork
+    when Article, ConferenceItem, GenericWork
       return true if peer_reviewed?(work: work) &&
                      work.record_level_file_version_declaration &&
                      work_has_public_files?(work: work, max_embargo_mths: 0) &&
                      coalition_s_funder?(work: work)
+
     # Books
-    when Book || BookContribution
-      return true if work_has_public_files?(work: work, max_embargo_mths: 12) && 
-                     coalition_s_funder?(work: work)         
-      
-    else
-      return false
+    when Book, BookContribution
+      return true if work_has_public_files?(work: work, max_embargo_mths: 12) &&
+                     coalition_s_funder?(work: work)
     end
+
+    false
   end
 
-  private
+  # TODO: implement a way to find this
+  def self.coalition_s_funder?(work:)
+    # Funding from coalition S organisations - Derived from funders metadata and
+    #   checked against list of coalition S funders
+    return true if work.funder
+    false
+  end
 
-    # TODO: implement a way to find this
-    def self.coalition_s_funder?(work:)
-      # Funding from coalition S organisations - Derived from funders metadata
-      #   checked against list of coalition S funders (potentially sourced from fundref)
-      # Possible ways to access:
-      #   * ror.org includes Crossref Funder ID in Other Identifiers - modify funder_api_data to return
-      #       see: https://ror.org/00cwqg982
-      #   * crossref.org https://api.crossref.org/funders?query=BBSRC
-      #   * https://gitlab.com/crossref/open_funder_registry
-      #       how often does it need to be updated?
-      #       use this first, and api as backup?
-      true
-    end
+  private_class_method :coalition_s_funder?
 
-    def self.peer_reviewed?(work:)
-      return true if work.refereed == 'Peer-reviewed'
-      false
-    end
+  def self.peer_reviewed?(work:)
+    return true if work.refereed == 'Peer-reviewed'
+    false
+  end
 
-    def self.work_has_public_files?(work:, max_embargo_mths:)
-      open_filesets = work.file_sets.map(&:open_access?)
-      return false unless open_filesets.any? { |ab| (ab == true) }
-      return true if embargo_within_max_allowed_age?(work: work, max_embargo_mths: max_embargo_mths)
-      false
-    end
+  private_class_method :peer_reviewed?
 
-    def self.embargo_within_max_allowed_age?(work:, max_embargo_mths:)
-      return true unless work.embargo_id
-      embargo = Hydra::AccessControls::Embargo.find(work.embargo_id)
-      return false if embargo.embargo_release_date
-      return true unless embargo.embargo_history
-      return false if max_embargo_mths.zero?
-      age = embargo_age(embargo_added: embargo.create_date,
-                  history_msg: embargo.embargo_history)
-      return true if age < max_embargo_mths
-      false
-    end
+  def self.work_has_public_files?(work:, max_embargo_mths:)
+    open_filesets = work.file_sets.map(&:open_access?)
+    return false unless open_filesets.any? { |ab| (ab == true) }
+    return true if embargo_within_max_allowed_age?(work: work, max_embargo_mths: max_embargo_mths)
+    false
+  end
 
-    # find the embargo age using the embargo's created date and dates out of the history info
-    def self.embargo_age(embargo_added:, history_msg:)
-      # Explanation:
-      # Embargo release date is transient... once deactivated, it is only available in the history message
-      # The message comes from hydra-access-controls.en.yml, with the following text:
-      #   An %{state} embargo was deactivated on %{deactivate_date}.  Its release date was %{release_date}.
-      #   Visibility during embargo was %{visibility_during} and intended visibility after embargo was %{visibility_after}
-      # Multiple deactivated messages can exist in the history array. The last is the most recent embargo release action.
-      # It is also important to note that the embargo is not necessarily deactivated on the embargo release date, but the
-      # work IS considered open as of the release date. So we need to look for the earlier of these two dates.
+  private_class_method :work_has_public_files?
 
-      # pull deactivated & released dates out of the most recent history message
-      (deactivated, released) = history_msg.last.scan(/\d{4}-\d{2}-\d{2}/)
-      # parse into Date objects
-      deactivated_date = Date.parse(deactivated)
-      embargo_date = Date.parse(released)
-      embargo_ended = [deactivated_date, embargo_date].min
-      # find the number of months between the two dates (NOT rounded)
-      (((embargo_ended - embargo_added).to_f)/365 * 12)
-    end
+  def self.embargo_within_max_allowed_age?(work:, max_embargo_mths:)
+    return true unless work.embargo_id
+    embargo = work.embargo
+    return false if embargo.embargo_release_date
+    return true unless embargo.embargo_history
+    return false if max_embargo_mths.zero?
+    age = embargo_age(embargo_added: embargo.create_date,
+                      history_msg: embargo.embargo_history)
+    return true if age < max_embargo_mths
+    false
+  end
+
+  private_class_method :embargo_within_max_allowed_age?
+
+  # find the embargo age using the embargo's created date and dates out of the history info
+  def self.embargo_age(embargo_added:, history_msg:)
+    # Explanation:
+    # Embargo release date is transient... once deactivated, it is only available in the history message
+    # The message comes from hydra-access-controls.en.yml, with the following text:
+    #   An %{state} embargo was deactivated on %{deactivate_date}.  Its release date was %{release_date}.
+    #   Visibility during embargo was %{visibility_during} and intended visibility after embargo was %{visibility_after}
+    # Multiple deactivated messages can exist in the history array. The last is the most recent embargo release action.
+    # It is also important to note that the embargo is not necessarily deactivated on the embargo release date, but the
+    # work IS considered open as of the release date. So we need to look for the earlier of these two dates.
+
+    # pull deactivated & released dates out of the most recent history message
+    (deactivated, released) = history_msg.last.scan(/\d{4}-\d{2}-\d{2}/)
+    # parse into Date objects
+    deactivated_date = Date.parse(deactivated)
+    embargo_date = Date.parse(released)
+    embargo_ended = [deactivated_date, embargo_date].min
+    # find the number of months between the two dates (NOT rounded)
+    (embargo_ended - embargo_added).to_f / 365 * 12
+  end
+
+  private_class_method :embargo_age
 end

--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -1,83 +1,91 @@
 class OpenAccessService
-  def self.unrestricted_use_files_for?(work:)
-    case work
+  include MultipleMetadataFieldsHelper
 
+  def initialize(work:)
+    @work = work
+  end
+  attr_reader :work
+
+  def unrestricted_use_files?
+    case work
     # Scholarly articles
     when Article, ConferenceItem, GenericWork
-      return true if peer_reviewed?(work: work) &&
+      return true if peer_reviewed? &&
                      work.record_level_file_version_declaration &&
-                     work_has_public_files?(work: work, max_embargo_mths: 0) &&
-                     coalition_s_funder?(work: work)
-
+                     public_files?(max_embargo_mths: 0) &&
+                     coalition_s?
     # Books
     when Book, BookContribution
-      return true if work_has_public_files?(work: work, max_embargo_mths: 12) &&
-                     coalition_s_funder?(work: work)
+      return true if public_files?(max_embargo_mths: 12) &&
+                     coalition_s?
+    end
+    false
+  end
+
+  private
+
+    def coalition_s?
+      return false unless work.funder
+      # parse funder string into a valid hash and break this into an array of DOI's
+      data_hash = get_model(work.funder, nil, 'funder')
+      funder_doi_array = data_hash&.map { |c| [c['funder_doi']].reject(&:blank?).join(', ') } || []
+      # process the array of DOI's, looking for the "broader" attribute which tells us this is a Plan S funder.
+      funder_doi_array.each do |doi|
+        return true if funder_doi?(doi: doi)
+      end
+      # possible secondary check by funder name needed?
+      false
     end
 
-    false
-  end
+    # TODO: verify the doi by checking new table once it exists
+    def funder_doi?(doi:)
+      # return true if PlanSFunder.where(doi: doi, status: 'active')
+      return true if doi
+      false
+    end
 
-  # TODO: implement a way to find this
-  def self.coalition_s_funder?(work:)
-    # Funding from coalition S organisations - Derived from funders metadata and
-    #   checked against list of coalition S funders
-    return true if work.funder
-    false
-  end
+    def peer_reviewed?
+      return true if work.refereed == 'Peer-reviewed'
+      false
+    end
 
-  private_class_method :coalition_s_funder?
+    def public_files?(max_embargo_mths:)
+      open_filesets = work.file_sets.map(&:open_access?)
+      return false unless open_filesets.any? { |ab| (ab == true) }
+      return true if embargo_within_max_allowed_age?(max_embargo_mths: max_embargo_mths)
+      false
+    end
 
-  def self.peer_reviewed?(work:)
-    return true if work.refereed == 'Peer-reviewed'
-    false
-  end
+    def embargo_within_max_allowed_age?(max_embargo_mths:)
+      return true unless work.embargo_id
+      embargo = work.embargo
+      return false if embargo.embargo_release_date
+      return true unless embargo.embargo_history
+      return false if max_embargo_mths.zero?
+      age = embargo_age(embargo_added: embargo.create_date,
+                        history_msg: embargo.embargo_history)
+      return true if age < max_embargo_mths
+      false
+    end
 
-  private_class_method :peer_reviewed?
+    # find the embargo age using the embargo's created date and dates out of the history info
+    def embargo_age(embargo_added:, history_msg:)
+      # Explanation:
+      # Embargo release date is transient... once deactivated, it is only available in the history message
+      # The message comes from hydra-access-controls.en.yml, with the following text:
+      #   An %{state} embargo was deactivated on %{deactivate_date}.  Its release date was %{release_date}.
+      #   Visibility during embargo was %{visibility_during} and intended visibility after embargo was %{visibility_after}
+      # Multiple deactivated messages can exist in the history array. The last is the most recent embargo release action.
+      # It is also important to note that the embargo is not necessarily deactivated on the embargo release date, but the
+      # work IS considered open as of the release date. So we need to look for the earlier of these two dates.
 
-  def self.work_has_public_files?(work:, max_embargo_mths:)
-    open_filesets = work.file_sets.map(&:open_access?)
-    return false unless open_filesets.any? { |ab| (ab == true) }
-    return true if embargo_within_max_allowed_age?(work: work, max_embargo_mths: max_embargo_mths)
-    false
-  end
-
-  private_class_method :work_has_public_files?
-
-  def self.embargo_within_max_allowed_age?(work:, max_embargo_mths:)
-    return true unless work.embargo_id
-    embargo = work.embargo
-    return false if embargo.embargo_release_date
-    return true unless embargo.embargo_history
-    return false if max_embargo_mths.zero?
-    age = embargo_age(embargo_added: embargo.create_date,
-                      history_msg: embargo.embargo_history)
-    return true if age < max_embargo_mths
-    false
-  end
-
-  private_class_method :embargo_within_max_allowed_age?
-
-  # find the embargo age using the embargo's created date and dates out of the history info
-  def self.embargo_age(embargo_added:, history_msg:)
-    # Explanation:
-    # Embargo release date is transient... once deactivated, it is only available in the history message
-    # The message comes from hydra-access-controls.en.yml, with the following text:
-    #   An %{state} embargo was deactivated on %{deactivate_date}.  Its release date was %{release_date}.
-    #   Visibility during embargo was %{visibility_during} and intended visibility after embargo was %{visibility_after}
-    # Multiple deactivated messages can exist in the history array. The last is the most recent embargo release action.
-    # It is also important to note that the embargo is not necessarily deactivated on the embargo release date, but the
-    # work IS considered open as of the release date. So we need to look for the earlier of these two dates.
-
-    # pull deactivated & released dates out of the most recent history message
-    (deactivated, released) = history_msg.last.scan(/\d{4}-\d{2}-\d{2}/)
-    # parse into Date objects
-    deactivated_date = Date.parse(deactivated)
-    embargo_date = Date.parse(released)
-    embargo_ended = [deactivated_date, embargo_date].min
-    # find the number of months between the two dates (NOT rounded)
-    (embargo_ended - embargo_added).to_f / 365 * 12
-  end
-
-  private_class_method :embargo_age
+      # pull deactivated & released dates out of the most recent history message
+      (deactivated, released) = history_msg.last.scan(/\d{4}-\d{2}-\d{2}/)
+      # parse into Date objects
+      deactivated_date = Date.parse(deactivated)
+      embargo_date = Date.parse(released)
+      embargo_ended = [deactivated_date, embargo_date].min
+      # find the number of months between the two dates (NOT rounded)
+      (embargo_ended - embargo_added).to_f / 365 * 12
+    end
 end

--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -1,0 +1,80 @@
+class OpenAccessService
+  def self.unrestricted_use_files_for?(work:)
+    case work
+    # Scholarly articles
+    when Article || ConferenceItem || GenericWork
+      return true if peer_reviewed?(work: work) &&
+                     work.record_level_file_version_declaration &&
+                     work_has_public_files?(work: work, max_embargo_mths: 0) &&
+                     coalition_s_funder?(work: work)
+    # Books
+    when Book || BookContribution
+      return true if work_has_public_files?(work: work, max_embargo_mths: 12) && 
+                     coalition_s_funder?(work: work)         
+      
+    else
+      return false
+    end
+  end
+
+  private
+
+    # TODO: implement a way to find this
+    def self.coalition_s_funder?(work:)
+      # Funding from coalition S organisations - Derived from funders metadata
+      #   checked against list of coalition S funders (potentially sourced from fundref)
+      # Possible ways to access:
+      #   * ror.org includes Crossref Funder ID in Other Identifiers - modify funder_api_data to return
+      #       see: https://ror.org/00cwqg982
+      #   * crossref.org https://api.crossref.org/funders?query=BBSRC
+      #   * https://gitlab.com/crossref/open_funder_registry
+      #       how often does it need to be updated?
+      #       use this first, and api as backup?
+      true
+    end
+
+    def self.peer_reviewed?(work:)
+      return true if work.refereed == 'Peer-reviewed'
+      false
+    end
+
+    def self.work_has_public_files?(work:, max_embargo_mths:)
+      open_filesets = work.file_sets.map(&:open_access?)
+      return false unless open_filesets.any? { |ab| (ab == true) }
+      return true if embargo_within_max_allowed_age?(work: work, max_embargo_mths: max_embargo_mths)
+      false
+    end
+
+    def self.embargo_within_max_allowed_age?(work:, max_embargo_mths:)
+      return true unless work.embargo_id
+      embargo = Hydra::AccessControls::Embargo.find(work.embargo_id)
+      return false if embargo.embargo_release_date
+      return true unless embargo.embargo_history
+      return false if max_embargo_mths.zero?
+      age = embargo_age(embargo_added: embargo.create_date,
+                  history_msg: embargo.embargo_history)
+      return true if age < max_embargo_mths
+      false
+    end
+
+    # find the embargo age using the embargo's created date and dates out of the history info
+    def self.embargo_age(embargo_added:, history_msg:)
+      # Explanation:
+      # Embargo release date is transient... once deactivated, it is only available in the history message
+      # The message comes from hydra-access-controls.en.yml, with the following text:
+      #   An %{state} embargo was deactivated on %{deactivate_date}.  Its release date was %{release_date}.
+      #   Visibility during embargo was %{visibility_during} and intended visibility after embargo was %{visibility_after}
+      # Multiple deactivated messages can exist in the history array. The last is the most recent embargo release action.
+      # It is also important to note that the embargo is not necessarily deactivated on the embargo release date, but the
+      # work IS considered open as of the release date. So we need to look for the earlier of these two dates.
+
+      # pull deactivated & released dates out of the most recent history message
+      (deactivated, released) = history_msg.last.scan(/\d{4}-\d{2}-\d{2}/)
+      # parse into Date objects
+      deactivated_date = Date.parse(deactivated)
+      embargo_date = Date.parse(released)
+      embargo_ended = [deactivated_date, embargo_date].min
+      # find the number of months between the two dates (NOT rounded)
+      (((embargo_ended - embargo_added).to_f)/365 * 12)
+    end
+end

--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -33,14 +33,11 @@ class OpenAccessService
       funder_doi_array.each do |doi|
         return true if funder_doi?(doi: doi)
       end
-      # possible secondary check by funder name needed?
       false
     end
 
-    # TODO: verify the doi by checking new table once it exists
     def funder_doi?(doi:)
-      # return true if PlanSFunder.where(doi: doi, status: 'active')
-      return true if doi
+      return true unless PlanSFunder.where(funder_doi: doi, funder_status: 'active').empty?
       false
     end
 

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -12,7 +12,7 @@ if ENV['DB_ADAPTER'] != 'nulldb' && db_created?
 
     # Add any models that you do not want to be multi-tenanted, but remain in the global (public) namespace.
     # A typical example would be a Customer or Tenant model that stores each Tenant's information.
-    config.excluded_models = %w{ Account AccountCrossSearch DomainName Endpoint User UserStat SolrEndpoint FcrepoEndpoint RedisEndpoint }
+    config.excluded_models = %w{ Account AccountCrossSearch DomainName Endpoint User UserStat SolrEndpoint FcrepoEndpoint RedisEndpoint PlanSFunder}
 
     # In order to migrate all of your Tenants you need to provide a list of Tenant names to Apartment.
     # You can make this dynamic by providing a Proc object to be called on migrations.

--- a/db/migrate/20230403180646_create_plan_s_funders.rb
+++ b/db/migrate/20230403180646_create_plan_s_funders.rb
@@ -1,0 +1,11 @@
+class CreatePlanSFunders < ActiveRecord::Migration[5.2]
+  def change
+    create_table :plan_s_funders do |t|
+      t.string :funder_doi, null: false
+      t.string :funder_name, null: false
+      t.string :funder_status, null: false
+      t.timestamps
+    end
+    add_index :plan_s_funders, :funder_doi
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_08_221006) do
+ActiveRecord::Schema.define(version: 2023_04_03_180646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -469,6 +469,15 @@ ActiveRecord::Schema.define(version: 2023_03_08_221006) do
     t.date "release_date"
     t.string "release_period"
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
+  end
+
+  create_table "plan_s_funders", force: :cascade do |t|
+    t.string "funder_doi", null: false
+    t.string "funder_name", null: false
+    t.string "funder_status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["funder_doi"], name: "index_plan_s_funders_on_funder_doi"
   end
 
   create_table "proxy_deposit_requests", id: :serial, force: :cascade do |t|

--- a/lib/data/plan_s_funders.csv
+++ b/lib/data/plan_s_funders.csv
@@ -1,0 +1,39 @@
+funder_doi,funder_name,funder_status
+http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
+https://doi.org/10.13039/501100002341,Academy of Finland,active
+http://dx.doi.org/10.13039/501100011858,African Academy of Sciences,active
+https://doi.org/10.13039/501100001665,Agence Nationale de la Recherche,active
+http://dx.doi.org/10.13039/100018231,Aligning Science Across Parkinson's,active
+https://doi.org/10.13039/501100000267,Arts and Humanities Research Council,active
+https://doi.org/10.13039/501100002428,Austrian Science Fund,active
+https://doi.org/10.13039/100000865,Bill & Melinda Gates Foundation,active
+https://doi.org/10.13039/501100000268,Biotechnology and Biological Sciences Research Council,active
+https://doi.org/10.13039/501100000269,Economic and Social Research Council,active
+https://doi.org/10.13039/501100000266,Engineering and Physical Sciences Research Council,active
+https://doi.org/10.13039/100010661,European Commission [Horizon 2020],active
+https://doi.org/10.13039/501100006636,FORTE,active
+https://doi.org/10.13039/501100001866,Fonds National de la Recherche Luxembourg,active
+http://dx.doi.org/10.13039/501100003151,Fonds de recherche du Québec-Nature et technologies,active
+https://doi.org/10.13039/501100000156,Fonds de recherche du Québec-Santé,active
+http://dx.doi.org/10.13039/100008240,Fonds de recherche du Québec-Société et culture,active
+https://doi.org/10.13039/501100001862,Formas,active
+https://doi.org/10.13039/501100001871,Fundação para a Ciência e a Tecnologia,active
+http://dx.doi.org/10.13039/501100010300,Higher Council for Science and Technology,active
+https://doi.org/10.13039/100000011,Howard Hughes Medical Institute,active
+http://dx.doi.org/10.13039/501100006041,Innovate UK,active
+https://doi.org/10.13039/501100000265,Medical Research Council,active
+https://doi.org/10.13039/501100004281,Narodowe Centrum Nauki,active
+https://doi.org/10.13039/501100000270,Natural Environment Research Council,active
+https://doi.org/10.13039/501100003246,Nederlandse Organisatie voor Wetenschappelijk Onderzoek,active
+https://doi.org/10.13039/501100005416,Research Council of Norway,active
+https://doi.org/10.13039/501100004472,Riksbankens Jubileumsfond,active
+https://doi.org/10.13039/501100001711,Schweizerischer Nationalfonds zur Förderung der Wissenschaftlichen Forschung,active
+https://doi.org/10.13039/501100001602,Science Foundation Ireland,active
+https://doi.org/10.13039/501100000271,Science and Technology Facilities Council,active
+http://dx.doi.org/10.13039/501100004329,Slovenian Research Agency,active
+http://dx.doi.org/10.13039/501100001322,South African Medical Research Council,active
+http://dx.doi.org/10.13039/501100011730,Templeton World Charity Foundation,active
+http://dx.doi.org/10.13039/100014013,UKRI,active
+https://doi.org/10.13039/501100001858,Vinnova,active
+https://doi.org/10.13039/100004423,WHO,active
+https://doi.org/10.13039/100004440,Wellcome Trust,active

--- a/lib/tasks/funders.rake
+++ b/lib/tasks/funders.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :hyku do
+  desc "maintain PlanSFunder table"
+  task maintain_funders: :environment do
+    MaintainPlanSFunders.call
+    # funders_to_reindex = MaintainPlanSFunders.call
+    # @TODO: This is where we would find all works in each
+    # tenant that are using any of the funders returned above,
+    # and then reindex each of them.
+  end
+end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :book do
+    transient do
+      user { FactoryBot.create(:user) }
+    end
+
+    title { ["Test book"] }
+
+    factory :book_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryBot.create(:file_set,
+                                                  user: evaluator.user,
+                                                  title: ['A Contained Generic File'])
+      end
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user)
+    end
+  end
+end

--- a/spec/lib/data/plan_s_funders.csv
+++ b/spec/lib/data/plan_s_funders.csv
@@ -1,0 +1,4 @@
+funder_doi,funder_name,funder_status
+http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
+https://doi.org/10.13039/501100002341,Academy of Finland,active
+http://dx.doi.org/10.13039/501100011858,African Academy of Sciences,active

--- a/spec/lib/data/plan_s_funders_updated.csv
+++ b/spec/lib/data/plan_s_funders_updated.csv
@@ -1,0 +1,3 @@
+funder_doi,funder_name,funder_status
+http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
+https://doi.org/10.13039/501100002341,Academy of Finland,inactive

--- a/spec/services/maintain_plan_s_funders_spec.rb
+++ b/spec/services/maintain_plan_s_funders_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe MaintainPlanSFunders do
+  let(:original_csv_path) { 'spec/lib/data/plan_s_funders.csv' }
+  let(:updated_csv_path) { 'spec/lib/data/plan_s_funders_updated.csv' }
+  let(:original_array) { ["http://dx.doi.org/10.13039/100005393", "https://doi.org/10.13039/501100002341", "http://dx.doi.org/10.13039/501100011858"] }
+  let(:updated_array) { ["http://dx.doi.org/10.13039/100005393", "https://doi.org/10.13039/501100002341"] }
+
+  describe '#call' do
+    before do
+      PlanSFunder.destroy_all
+    end
+
+    it 'loads PlanSFunder data' do
+      output = described_class.call(csv_path: original_csv_path)
+      expect(PlanSFunder.count).to eq 3
+      expect(output).to eq(original_array)
+    end
+
+    it 'updates PlanSFunder data' do
+      output = described_class.call(csv_path: updated_csv_path)
+      expect(PlanSFunder.count).to eq 2
+      expect(PlanSFunder.where(funder_doi: "https://doi.org/10.13039/501100002341").first.funder_status).to eq('inactive')
+      expect(output).to eq(updated_array)
+    end
+  end
+end

--- a/spec/services/open_access_service_spec.rb
+++ b/spec/services/open_access_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenAccessService do
   let(:funder) do
     ["[{\"funder_name\":\"Biotechnology and Biological Sciences Research Council\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000268\",\"funder_position\":\"0\",\"funder_isni\":\"0000 0001 2189 3037\",\"funder_ror\":\"https://ror.org/00cwqg982\"},{\"funder_name\":\"British Academy\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000286\",\"funder_position\":\"1\",\"funder_isni\":\"0000 0004 0411 8698\",\"funder_ror\":\"https://ror.org/0302b4677\"}]"]
   end
-  let(:plan_s_funder) { PlanSFunder.new(funder_doi: 'http://dx.doi.org/10.13039/501100000268', funder_name: 'Biotechnology and Biological Sciences Research Council', funder_status: 'active' ) }
+  let(:plan_s_funder) { PlanSFunder.new(funder_doi: 'http://dx.doi.org/10.13039/501100000268', funder_name: 'Biotechnology and Biological Sciences Research Council', funder_status: 'active') }
 
   # rubocop:enable Metrics/LineLength
 

--- a/spec/services/open_access_service_spec.rb
+++ b/spec/services/open_access_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe OpenAccessService do
   let(:funder) do
     ["[{\"funder_name\":\"Biotechnology and Biological Sciences Research Council\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000268\",\"funder_position\":\"0\",\"funder_isni\":\"0000 0001 2189 3037\",\"funder_ror\":\"https://ror.org/00cwqg982\"},{\"funder_name\":\"British Academy\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000286\",\"funder_position\":\"1\",\"funder_isni\":\"0000 0004 0411 8698\",\"funder_ror\":\"https://ror.org/0302b4677\"}]"]
   end
+  let(:plan_s_funder) { PlanSFunder.new(funder_doi: 'http://dx.doi.org/10.13039/501100000268', funder_name: 'Biotechnology and Biological Sciences Research Council', funder_status: 'active' ) }
 
   # rubocop:enable Metrics/LineLength
 
@@ -29,7 +30,7 @@ RSpec.describe OpenAccessService do
         before do
           allow(work).to receive(:file_sets).and_return([filesets])
           allow(filesets).to receive(:open_access?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:coalition_s?).and_return(true)
+          allow(PlanSFunder).to receive(:where).and_return([plan_s_funder])
         end
 
         it { is_expected.to be_truthy }
@@ -39,7 +40,7 @@ RSpec.describe OpenAccessService do
         before do
           allow(work).to receive(:file_sets).and_return([filesets])
           allow(filesets).to receive(:open_access?).and_return(true)
-          allow_any_instance_of(described_class).to receive(:coalition_s?).and_return(false)
+          allow(PlanSFunder).to receive(:where).and_return([])
         end
 
         it { is_expected.to be_falsey }

--- a/spec/services/open_access_service_spec.rb
+++ b/spec/services/open_access_service_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenAccessService do
+  subject { described_class.unrestricted_use_files_for?(work: work) }
+
+  let(:book) { build(:book_with_one_file, funder: funder) }
+  let(:generic_work) do
+    build(:work_with_one_file,
+          refereed: 'Peer-reviewed',
+          record_level_file_version_declaration: '1',
+          funder: funder)
+  end
+  let(:image) { build(:image) }
+  let(:filesets) { double }
+  let(:embargo) { double }
+  let(:funder) { [] }
+
+  describe '#unrestricted_use_files_for?' do
+    context 'for scholarly articles' do
+      let(:work) { generic_work }
+
+      context 'when unrestricted use' do
+        before do
+          allow(work).to receive(:file_sets).and_return([filesets])
+          allow(filesets).to receive(:open_access?).and_return(true)
+        end
+        it 'returns true' do
+          expect(subject).to be_truthy
+        end
+      end
+    end
+
+    context 'for books' do
+      let(:work) { book }
+
+      context 'when unrestricted use' do
+        before do
+          allow(work).to receive(:file_sets).and_return([filesets])
+          allow(filesets).to receive(:open_access?).and_return(true)
+        end
+
+        it 'returns true' do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context 'when under embargo < 12 months' do
+        before do
+          allow(work).to receive(:file_sets).and_return([filesets])
+          allow(filesets).to receive(:open_access?).and_return(true)
+          allow(described_class).to receive(:embargo_within_max_allowed_age?).and_return(true)
+        end
+
+        it 'returns true' do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context 'when under embargo > 12 months' do
+        before do
+          allow(work).to receive(:file_sets).and_return([filesets])
+          allow(filesets).to receive(:open_access?).and_return(true)
+          allow(described_class).to receive(:embargo_within_max_allowed_age?).and_return(false)
+        end
+
+        it 'returns false' do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+
+    context 'for other work types' do
+      let(:work) { image }
+
+      it 'returns false unless in listed classes' do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+
+  describe '#coalition_s_funder?' do
+    subject { described_class.send(:coalition_s_funder?, work: work) }
+
+    let(:work) { generic_work }
+
+    it { is_expected.to be_truthy }
+  end
+
+  describe '#embargo_within_max_allowed_age?' do
+    let(:work) { generic_work }
+    let(:embargo) do
+      double(embargo_release_date: release,
+             embargo_history: history_msg,
+             create_date: created)
+    end
+    let(:created) { Date.new(2023, 1, 1) }
+    let(:history_msg) { ['An active embargo was deactivated on 2023-03-27. Its release date was 2023-03-28T00:00:00+00:00. Visibility during embargo was restricted and intended visibility after embargo was open'] }
+
+    before do
+      allow(work).to receive(:embargo_id).and_return('12345')
+      allow(work).to receive(:embargo).and_return(embargo)
+    end
+
+    describe 'when there is an embargo date' do
+      subject do
+        described_class.send(:embargo_within_max_allowed_age?,
+                             work: work,
+                             max_embargo_mths: 5)
+      end
+
+      let(:release) { Date.new(2023, 3, 30) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    describe 'when max months is zero' do
+      subject do
+        described_class.send(:embargo_within_max_allowed_age?,
+                             work: work,
+                             max_embargo_mths: 0)
+      end
+
+      let(:release) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    describe 'when embargo longer than max months' do
+      subject do
+        described_class.send(:embargo_within_max_allowed_age?,
+                             work: work,
+                             max_embargo_mths: 1)
+      end
+
+      let(:release) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    describe 'when embargo shorter than max months' do
+      subject do
+        described_class.send(:embargo_within_max_allowed_age?,
+                             work: work,
+                             max_embargo_mths: 12)
+      end
+
+      let(:release) { nil }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
# Story

- [x] Creates an open access service, encapsulating the logic used to determine whether a work will be labeled "Open Access" based on cOAlition S guidelines.
- [x] Adds a method to all worktypes utilizing this service.
- [x] Adds the indexed value from OpenAccessService call into OAI feed
- [x] Rake task to seed PlanSFunder table with data `rake hyku:maintain_funders`

see: https://www.coalition-s.org/technical-guidance_and_requirements/

Refs #331 and #104 

# Expected Behavior After Changes

Open Access determination appears in OAI feed.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-04-20 at 2 08 01 PM](https://user-images.githubusercontent.com/17851674/233452206-19a57369-3722-4f22-bd50-60c328f5e5ec.png)

</details>

# Notes
Ticket #375 remains to implement the API calls and reindexing of works.