### PR TITLE
Add an additional check for blank string array

### DIFF
--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -79,7 +79,7 @@ module Ubiquity
 
     # remove hash keys with value of nil, "", and "NaN"
     def remove_hash_keys_with_empty_and_nil_values(data)
-      if (data.present? && data.class == Array)
+      if (data&.join.present? && data.class == Array)
         new_data = data.map do |hash|
           ['contributor_orcid', 'contributor_isni', 'creator_orcid', 'creator_isni', 'editor_isni', 'editor_orcid'].each do|ele|
             hash[ele] = hash[ele].strip.chomp('/').split('/').last.gsub(/[^a-z0-9X-]/, '') if hash[ele].present?


### PR DESCRIPTION
ref #222 

`data` would come in as `[""]` and pass the current guards.  This commit adds a `join` to check for arrays of blank strings.

This was not the original ticket but an additional bug that I ran into.  The fix should get the imports to run now.