### PR TITLE
Addressing SOLR maxBooleanClauses for WorkType export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 
 # Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have
 #            a quick scan of what version we're assuming/working with.
-gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '9d57ec6c9e1eb7f4775b0b65c82fde48a5a49b58'
+gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: 'd14d55fbf4a9b6c7a3275346725da9b853236287'
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 9d57ec6c9e1eb7f4775b0b65c82fde48a5a49b58
-  ref: 9d57ec6c9e1eb7f4775b0b65c82fde48a5a49b58
+  revision: d14d55fbf4a9b6c7a3275346725da9b853236287
+  ref: d14d55fbf4a9b6c7a3275346725da9b853236287
   specs:
     bulkrax (5.1.0)
       bagit (~> 0.4)


### PR DESCRIPTION
Incorporate https://github.com/samvera-labs/bulkrax/pull/776

> Prior to this commit, we were querying all of the candidate file set
> IDs for the associated work type.  In the case fo the below exporter,
> we had 1196 IDs to query.
>
>
> As we were testing if there was a query size limit, we noticed that we
> could query 1024 IDs but not 1025.  We add other query parameters, to
> bump the query size, but at 1024 IDs things worked.  At 1025 they
> failed.
>
> Digging further, we saw that there is hard (yet configurable) limit
> for SOLR query OR clauses.  In our case, 1024.  (Hint: if you powers
> of 2, dig a little).
>
> With this commit, we instead request 512 IDs at a time and join those
> results into a single array.
>
> Note: there are other queries that will need similar fixing but for
> the time being, this (we hope) resolves a client urgency.
>
> See: https://kew.iro.bl.uk/exporters/146?locale=en
> See: https://solr.apache.org/guide/8_1/query-settings-in-solrconfig.html#query-sizing-and-warming
>
> Related to:
>  - https://github.com/scientist-softserv/britishlibrary/issues/289
>  - https://github.com/samvera-labs/bulkrax/pull/749
>  - https://github.com/samvera-labs/bulkrax/issues/775

