### PR TITLE
Fix load of prior values for edit

### DIFF
--- a/app/views/hyrax/base/_form_declaration.html.erb
+++ b/app/views/hyrax/base/_form_declaration.html.erb
@@ -1,4 +1,4 @@
 <% if curation_concern.respond_to?(:record_level_file_version_declaration) %>
-  <% checked = true if curation_concern.record_level_file_version_declaration %>
+  <% checked = true if curation_concern.record_level_file_version_declaration == '1' %>
   <%= f.input :record_level_file_version_declaration, as: :boolean, label: t('hyrax.base.form_files.record_level_file_version_declaration_question', model: curation_concern.class), input_html: { checked: checked } %>
 <% end %>


### PR DESCRIPTION
# Story

Refs #330 

# Expected Behavior Before Changes

File tab checkbox on edit view was always checked.

# Expected Behavior After Changes

File tab checkbox on edit view is checked appropriately based on value.

# Screenshots / Video

<details>
<summary></summary>

**Before**
![Screenshot 2023-04-10 at 4 25 22 PM](https://user-images.githubusercontent.com/17851674/230991720-dcb75660-dd7b-42f3-b6bd-7d8ed54ef948.png)

**After**
![Screenshot 2023-04-10 at 4 25 45 PM](https://user-images.githubusercontent.com/17851674/230991788-319d04ec-ad31-446f-917f-810d36c24eb2.png)

</details>

# Notes