### PR TITLE
Update iiif_print gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 
 # Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have
 #            a quick scan of what version we're assuming/working with.
-gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '96f37df8640ab8d7d739942e9d907f48b212e4ab'
+gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: 'main'
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: e3384284a9992df867b7bedc256c82485355551d
+  revision: 25e1785f78d41b7acb259c7080ec15c368173a33
   branch: main
   specs:
     iiif_print (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 96f37df8640ab8d7d739942e9d907f48b212e4ab
-  ref: 96f37df8640ab8d7d739942e9d907f48b212e4ab
+  revision: 14c529d45c0dfc8ec4eca0207a6f5d4df182dbce
+  ref: main
   specs:
     bulkrax (5.1.0)
       bagit (~> 0.4)

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -8,8 +8,6 @@ module Hyrax
 
     module DisplayImagePresenterDecorator
       include Hyrax::IiifAv::DisplaysContent
-      # override Hyrax method to avoid double items in the manifest
-      def display_image; end
 
       # override Hyrax to keep pdfs from gumming up the v3 manifest
       # in app/presenters/hyrax/iiif_manifest_presenter.rb

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -15,9 +15,5 @@ IiifPrint.config do |config|
   # @example
   #   config.excluded_model_name_solr_field_key = 'some_solr_field_key'
 
-  # Configure how the manifest sorts the canvases, by default it sorts by :title,
-  # but a different model property may be desired such as :date_published
-  # @example
-  #   config.sort_iiif_manifest_canvases_by = :date_published
   config.default_iiif_manifest_version = 3
 end

--- a/spec/presenters/hyrax/iiif_manifest_presenter/display_image_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter/display_image_presenter_spec.rb
@@ -7,10 +7,4 @@ RSpec.describe Hyrax::IiifManifestPresenter::DisplayImagePresenter do
   it "includes Hyrax::IiifAv::DisplaysContent" do
     expect(described_class.include?(Hyrax::IiifAv::DisplaysContent)).to be true
   end
-
-  describe "#display_image" do
-    subject { presenter.display_image }
-
-    it { is_expected.to be_nil }
-  end
 end


### PR DESCRIPTION
# Story
This updates IiifPrint and Bulkrax. 
Refs #381 

# Expected Behavior After Changes

This IiifPrint update includes error fixes along with the following improvements:
- updated child work title to resolve potential duplicate titles and ordering issues
- child work titles summarized in viewer
- ability to render authorities
- efficiency improvements

The Bulkrax update includes fixes for zip file uploading.

# Notes
Tested with a variety of Bulkrax importers, as well as UI import, and all imports and viewers work as expected.

![Screenshot 2023-04-14 at 3 55 56 PM](https://user-images.githubusercontent.com/17851674/232143064-a06feb0c-4800-46ac-af8a-4feb86df7e30.png)
