### PR TITLE
[i383] - set PROD EXTERNAL_IIIF_URL for iiif serverless

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -163,7 +163,7 @@ extraEnvVars: &envVars
   - name: OMP_THREAD_LIMIT
     value: "1"
   - name: EXTERNAL_IIIF_URL
-    value: https://d2ltm8fy0v0agc.cloudfront.net/iiif/2
+    value: https://dudgkgvsbllzg.cloudfront.net/iiif/2
 
 worker:
   replicaCount: 1

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -162,6 +162,8 @@ extraEnvVars: &envVars
     value: https://bcbcbdd237984028a7d0b76d96ba90dd@o1008683.ingest.sentry.io/6745017
   - name: OMP_THREAD_LIMIT
     value: "1"
+  - name: EXTERNAL_IIIF_URL
+    value: https://d2ltm8fy0v0agc.cloudfront.net/iiif/2
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
# Story

Sets EXTERNAL_IIIF_URL env for prod, to enable serverless iiif.

Refs #383 

# Expected Behavior Before Changes

Images are served via iiif

# Expected Behavior After Changes

Images are served via cloudfront/fedora backed s3 when EXTERNAL_IIIF_URL is present