### PR TITLE
[i313] - A user should be able to search for all child metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 25e1785f78d41b7acb259c7080ec15c368173a33
+  revision: 033926d7d805a6bc409515515b17f62f9850524f
   branch: main
   specs:
     iiif_print (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 033926d7d805a6bc409515515b17f62f9850524f
+  revision: d231525d2552a652e71292c919520f1e9e62a4cb
   branch: main
   specs:
     iiif_print (1.0.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,7 +68,8 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv"
+      qf: IiifPrint.config.metadata_fields.keys.map { |attribute| "#{attribute}_tesim" }
+                   .join(' ') << "title_tesim description_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -17,6 +17,7 @@ IiifPrint.config do |config|
 
   config.default_iiif_manifest_version = 3
 
+  # @note These fields will appear in rendering order.
   config.metadata_fields = {
     alt_title: {},
     resource_type: {},


### PR DESCRIPTION
# Story

This PR was created in response to QA feedback. A user should be able to search for all of the child's metadata, from the parent UV.

Changes inspired by: https://gitlab.com/notch8/louisville-hyku/-/merge_requests/167

Co-author: @kirkkwang 

ref: https://github.com/scientist-softserv/britishlibrary/issues/313#issuecomment-1515177007

# Expected Behavior Before Changes

QA was unable to search for some of the metadata, such as contributor

![image](https://user-images.githubusercontent.com/10081604/233221327-c12d19d3-4a42-4a43-a5a5-60ffb6b77fdc.png)

![image](https://user-images.githubusercontent.com/10081604/233221254-67437f1d-6d03-4db2-a3c2-b2d643140415.png)


# Expected Behavior After Changes

- [ ] A user should be able to search for all of the child's metadata, from the parent UV. Search for contributor:

![image](https://user-images.githubusercontent.com/10081604/233221501-60d9f5ed-dae8-47a5-a48b-88572be6b081.png)



