### PR TITLE
Adds job to reindex works as PlanSFunder table is maintained.

### DIFF
--- a/app/jobs/reindex_funders_job.rb
+++ b/app/jobs/reindex_funders_job.rb
@@ -8,22 +8,22 @@ class ReindexFundersJob < ApplicationJob
       next if account.name == "search"
       account.switch do
         dois.each do |doi|
-          # find all ids in this tenant using this doi      
-          qry =  "funder_tesim:\"#{doi}\""
+          # find all ids in this tenant using this doi
+          qry = "funder_tesim:\"#{doi}\""
           ids = ActiveFedora::SolrService.query(
-            qry, 
-            fl: ActiveFedora.id_field, 
+            qry,
+            fl: ActiveFedora.id_field,
             rows: 100
           ).map { |x| x.fetch(ActiveFedora.id_field) }
 
           # reindex each work by id
           ids.each do |id|
-              ActiveFedora::Base.find(id)&.update_index
-              count_indexed +=1
+            ActiveFedora::Base.find(id)&.update_index
+            count_indexed += 1
           end
         end
       end
-    end 
-    Rails.logger.info("😈😈 reindexed #{count_indexed} works in all tenants")  
+    end
+    Rails.logger.info("😈😈 reindexed #{count_indexed} works in all tenants")
   end
 end

--- a/app/jobs/reindex_funders_job.rb
+++ b/app/jobs/reindex_funders_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ReindexFundersJob < ApplicationJob
+  # @param Array of funder DOIs to reindex
+  def perform(dois:)
+    count_indexed = 0
+    Account.find_each do |account|
+      next if account.name == "search"
+      account.switch do
+        dois.each do |doi|
+          # find all ids in this tenant using this doi      
+          qry =  "funder_tesim:\"#{doi}\""
+          ids = ActiveFedora::SolrService.query(
+            qry, 
+            fl: ActiveFedora.id_field, 
+            rows: 100
+          ).map { |x| x.fetch(ActiveFedora.id_field) }
+
+          # reindex each work by id
+          ids.each do |id|
+              ActiveFedora::Base.find(id)&.update_index
+              count_indexed +=1
+          end
+        end
+      end
+    end 
+    Rails.logger.info("😈😈 reindexed #{count_indexed} works in all tenants")  
+  end
+end

--- a/lib/data/plan_s_funders.csv
+++ b/lib/data/plan_s_funders.csv
@@ -1,39 +1,39 @@
 funder_doi,funder_name,funder_status
-http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
-https://doi.org/10.13039/501100002341,Academy of Finland,active
-http://dx.doi.org/10.13039/501100011858,African Academy of Sciences,active
-https://doi.org/10.13039/501100001665,Agence Nationale de la Recherche,active
-http://dx.doi.org/10.13039/100018231,Aligning Science Across Parkinson's,active
-https://doi.org/10.13039/501100000267,Arts and Humanities Research Council,active
-https://doi.org/10.13039/501100002428,Austrian Science Fund,active
-https://doi.org/10.13039/100000865,Bill & Melinda Gates Foundation,active
-https://doi.org/10.13039/501100000268,Biotechnology and Biological Sciences Research Council,active
-https://doi.org/10.13039/501100000269,Economic and Social Research Council,active
-https://doi.org/10.13039/501100000266,Engineering and Physical Sciences Research Council,active
-https://doi.org/10.13039/100010661,European Commission [Horizon 2020],active
-https://doi.org/10.13039/501100006636,FORTE,active
-https://doi.org/10.13039/501100001866,Fonds National de la Recherche Luxembourg,active
-http://dx.doi.org/10.13039/501100003151,Fonds de recherche du Québec-Nature et technologies,active
-https://doi.org/10.13039/501100000156,Fonds de recherche du Québec-Santé,active
-http://dx.doi.org/10.13039/100008240,Fonds de recherche du Québec-Société et culture,active
-https://doi.org/10.13039/501100001862,Formas,active
-https://doi.org/10.13039/501100001871,Fundação para a Ciência e a Tecnologia,active
-http://dx.doi.org/10.13039/501100010300,Higher Council for Science and Technology,active
-https://doi.org/10.13039/100000011,Howard Hughes Medical Institute,active
-http://dx.doi.org/10.13039/501100006041,Innovate UK,active
-https://doi.org/10.13039/501100000265,Medical Research Council,active
-https://doi.org/10.13039/501100004281,Narodowe Centrum Nauki,active
-https://doi.org/10.13039/501100000270,Natural Environment Research Council,active
-https://doi.org/10.13039/501100003246,Nederlandse Organisatie voor Wetenschappelijk Onderzoek,active
-https://doi.org/10.13039/501100005416,Research Council of Norway,active
-https://doi.org/10.13039/501100004472,Riksbankens Jubileumsfond,active
-https://doi.org/10.13039/501100001711,Schweizerischer Nationalfonds zur Förderung der Wissenschaftlichen Forschung,active
-https://doi.org/10.13039/501100001602,Science Foundation Ireland,active
-https://doi.org/10.13039/501100000271,Science and Technology Facilities Council,active
-http://dx.doi.org/10.13039/501100004329,Slovenian Research Agency,active
-http://dx.doi.org/10.13039/501100001322,South African Medical Research Council,active
-http://dx.doi.org/10.13039/501100011730,Templeton World Charity Foundation,active
-http://dx.doi.org/10.13039/100014013,UKRI,active
-https://doi.org/10.13039/501100001858,Vinnova,active
-https://doi.org/10.13039/100004423,WHO,active
-https://doi.org/10.13039/100004440,Wellcome Trust,active
+10.13039/100005393,American Roentgen Ray Society,active
+10.13039/501100002341,Academy of Finland,active
+10.13039/501100011858,African Academy of Sciences,active
+10.13039/501100001665,Agence Nationale de la Recherche,active
+10.13039/100018231,Aligning Science Across Parkinson's,active
+10.13039/501100000267,Arts and Humanities Research Council,active
+10.13039/501100002428,Austrian Science Fund,active
+10.13039/100000865,Bill & Melinda Gates Foundation,active
+10.13039/501100000268,Biotechnology and Biological Sciences Research Council,active
+10.13039/501100000269,Economic and Social Research Council,active
+10.13039/501100000266,Engineering and Physical Sciences Research Council,active
+10.13039/100010661,European Commission [Horizon 2020],active
+10.13039/501100006636,FORTE,active
+10.13039/501100001866,Fonds National de la Recherche Luxembourg,active
+10.13039/501100003151,Fonds de recherche du Québec-Nature et technologies,active
+10.13039/501100000156,Fonds de recherche du Québec-Santé,active
+10.13039/100008240,Fonds de recherche du Québec-Société et culture,active
+10.13039/501100001862,Formas,active
+10.13039/501100001871,Fundação para a Ciência e a Tecnologia,active
+10.13039/501100010300,Higher Council for Science and Technology,active
+10.13039/100000011,Howard Hughes Medical Institute,active
+10.13039/501100006041,Innovate UK,active
+10.13039/501100000265,Medical Research Council,active
+10.13039/501100004281,Narodowe Centrum Nauki,active
+10.13039/501100000270,Natural Environment Research Council,active
+10.13039/501100003246,Nederlandse Organisatie voor Wetenschappelijk Onderzoek,active
+10.13039/501100005416,Research Council of Norway,active
+10.13039/501100004472,Riksbankens Jubileumsfond,active
+10.13039/501100001711,Schweizerischer Nationalfonds zur Förderung der Wissenschaftlichen Forschung,active
+10.13039/501100001602,Science Foundation Ireland,active
+10.13039/501100000271,Science and Technology Facilities Council,active
+10.13039/501100004329,Slovenian Research Agency,active
+10.13039/501100001322,South African Medical Research Council,active
+10.13039/501100011730,Templeton World Charity Foundation,active
+10.13039/100014013,UKRI,active
+10.13039/501100001858,Vinnova,active
+10.13039/100004423,WHO,active
+10.13039/100004440,Wellcome Trust,active

--- a/lib/tasks/funders.rake
+++ b/lib/tasks/funders.rake
@@ -4,9 +4,10 @@ namespace :hyku do
   desc "maintain PlanSFunder table"
   task maintain_funders: :environment do
     MaintainPlanSFunders.call
-    # funders_to_reindex = MaintainPlanSFunders.call
-    # @TODO: This is where we would find all works in each
-    # tenant that are using any of the funders returned above,
-    # and then reindex each of them.
+  end
+
+  task reset_funders: :environment do
+    PlanSFunder.destroy_all
+    MaintainPlanSFunders.call
   end
 end

--- a/spec/lib/data/plan_s_funders.csv
+++ b/spec/lib/data/plan_s_funders.csv
@@ -1,4 +1,4 @@
 funder_doi,funder_name,funder_status
-http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
-https://doi.org/10.13039/501100002341,Academy of Finland,active
-http://dx.doi.org/10.13039/501100011858,African Academy of Sciences,active
+10.13039/100005393,American Roentgen Ray Society,active
+10.13039/501100002341,Academy of Finland,active
+10.13039/501100011858,African Academy of Sciences,active

--- a/spec/lib/data/plan_s_funders_updated.csv
+++ b/spec/lib/data/plan_s_funders_updated.csv
@@ -1,3 +1,3 @@
 funder_doi,funder_name,funder_status
-http://dx.doi.org/10.13039/100005393,American Roentgen Ray Society,active
-https://doi.org/10.13039/501100002341,Academy of Finland,inactive
+10.13039/100005393,American Roentgen Ray Society,active
+10.13039/501100002341,Academy of Finland,inactive

--- a/spec/services/maintain_plan_s_funders_spec.rb
+++ b/spec/services/maintain_plan_s_funders_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe MaintainPlanSFunders do
   let(:original_csv_path) { 'spec/lib/data/plan_s_funders.csv' }
   let(:updated_csv_path) { 'spec/lib/data/plan_s_funders_updated.csv' }
-  let(:original_array) { ["http://dx.doi.org/10.13039/100005393", "https://doi.org/10.13039/501100002341", "http://dx.doi.org/10.13039/501100011858"] }
-  let(:updated_array) { ["http://dx.doi.org/10.13039/100005393", "https://doi.org/10.13039/501100002341"] }
+  let(:original_array) { ["10.13039/100005393", "10.13039/501100002341", "10.13039/501100011858"] }
+  let(:updated_array) { ["10.13039/100005393", "10.13039/501100002341"] }
 
   describe '#call' do
     before do
@@ -20,7 +20,7 @@ RSpec.describe MaintainPlanSFunders do
     it 'updates PlanSFunder data' do
       output = described_class.call(csv_path: updated_csv_path)
       expect(PlanSFunder.count).to eq 2
-      expect(PlanSFunder.where(funder_doi: "https://doi.org/10.13039/501100002341").first.funder_status).to eq('inactive')
+      expect(PlanSFunder.where(funder_doi: "10.13039/501100002341").first.funder_status).to eq('inactive')
       expect(output).to eq(updated_array)
     end
   end


### PR DESCRIPTION
# Story

Refs #375 This is the first of several PR's for this issue. 

# Expected Behavior Before Changes

- Running `MaintainPlanSFunders.call` (or `rake hyku:maintain_funders`) did not do any reindexing of works affected. This is needed before initially loading the PlanSFunder table in each environment.
- The PlanSFunder CSVs contained the full DOIs. This is necessary because the API used to gather the data for the PlanSFunder table doesn't use a prefix consistent with the API which is used to find the funder on the works.

# Expected Behavior After Changes

- Running `MaintainPlanSFunders.call` (or `rake hyku:maintain_funders`) submits a job to the queue to reindex any jobs using any of the funders which were added, deactivated, or removed due to maintenance. 
- Adds `rake hyku:reset_funders` for testing - note that this only indexes the works using funders which are current. It does not track funders being removed.
- A message is logged counting the number of works reindexed by the job.
- The PlanSFunder CSVs contain only the portion of the DOI following the doi.org prefix.

# Screenshots / Video

<details>
<summary></summary>

<img width="996" alt="Screenshot 2023-04-24 at 7 19 43 PM" src="https://user-images.githubusercontent.com/17851674/234136070-dd263e3c-c374-4d50-b54c-ff8c1c7f6dac.png">
</details>

# Notes