### PR TITLE
Patch service to account for PlanSFunder changes

### DIFF
--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -37,7 +37,9 @@ class OpenAccessService
     end
 
     def funder_doi?(doi:)
-      return true unless PlanSFunder.where(funder_doi: doi, funder_status: 'active').empty?
+      # DOIs can begin with either http://doi.org or https://dx.doi.org so we verify only the numeric portion
+      cleaned_doi = doi.match(%r{https?://.*doi\.org/(.+)})[1]
+      return true unless PlanSFunder.where(funder_doi: cleaned_doi, funder_status: 'active').empty?
       false
     end
 

--- a/spec/services/open_access_service_spec.rb
+++ b/spec/services/open_access_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenAccessService do
   let(:funder) do
     ["[{\"funder_name\":\"Biotechnology and Biological Sciences Research Council\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000268\",\"funder_position\":\"0\",\"funder_isni\":\"0000 0001 2189 3037\",\"funder_ror\":\"https://ror.org/00cwqg982\"},{\"funder_name\":\"British Academy\",\"funder_doi\":\"http://dx.doi.org/10.13039/501100000286\",\"funder_position\":\"1\",\"funder_isni\":\"0000 0004 0411 8698\",\"funder_ror\":\"https://ror.org/0302b4677\"}]"]
   end
-  let(:plan_s_funder) { PlanSFunder.new(funder_doi: 'http://dx.doi.org/10.13039/501100000268', funder_name: 'Biotechnology and Biological Sciences Research Council', funder_status: 'active') }
+  let(:plan_s_funder) { PlanSFunder.new(funder_doi: '10.13039/501100000268', funder_name: 'Biotechnology and Biological Sciences Research Council', funder_status: 'active') }
 
   # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
# Story

Correct access to PlanSFunder data to use only a subset of the doi.

Based on PR https://github.com/scientist-softserv/britishlibrary/pull/391 which changed the data stored in the PlanSFunder table for doi. (It now only saves the numeric portion of the doi due to various options for the doi, and the need to match regardless of the full url.)

Refs #331 

# Expected Behavior Before Changes

Open access was not appearing on the OAI feed.

# Expected Behavior After Changes

The OAI feed now correctly determines Open Access status.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-04-26 at 9 27 47 AM](https://user-images.githubusercontent.com/17851674/234591017-a47b369f-edf5-4b7c-8dc1-b802248120b2.png)

</details>

# Notes