### PR TITLE
Handle removed user on stats page

### DIFF
--- a/app/services/hyrax/statistics/depositors/summary_decorator.rb
+++ b/app/services/hyrax/statistics/depositors/summary_decorator.rb
@@ -1,0 +1,27 @@
+# Override Hyrax 2.9.6 to stop error when trprting on deposits by since removed users
+#
+module Hyrax
+   module Statistics
+       module Depositors
+         module SummaryDecorator
+
+          def depositors
+            # step through the array by twos to get each pair
+            results.map do |key, deposits|
+              user = ::User.find_by_user_key(key)
+             # Don't freak out if user not found (they may have been removed)
+             if user
+               { key: key, deposits: deposits, user: user }
+             else
+               # Leave user undef and let the view work out what to do
+               { key: key, deposits: deposits }
+            end
+          end
+        end
+
+      end
+    end
+  end
+end
+
+Hyrax::Statistics::Depositors::Summary.prepend(Hyrax::Statistics::Depositors::SummaryDecorator)

--- a/app/services/hyrax/statistics/depositors/summary_decorator.rb
+++ b/app/services/hyrax/statistics/depositors/summary_decorator.rb
@@ -1,24 +1,22 @@
 # Override Hyrax 2.9.6 to stop error when trprting on deposits by since removed users
 #
 module Hyrax
-   module Statistics
-       module Depositors
-         module SummaryDecorator
-
-          def depositors
-            # step through the array by twos to get each pair
-            results.map do |key, deposits|
-              user = ::User.find_by_user_key(key)
-             # Don't freak out if user not found (they may have been removed)
-             if user
-               { key: key, deposits: deposits, user: user }
-             else
-               # Leave user undef and let the view work out what to do
-               { key: key, deposits: deposits }
+  module Statistics
+    module Depositors
+      module SummaryDecorator
+        def depositors
+          # step through the array by twos to get each pair
+          results.map do |key, deposits|
+            user = ::User.find_by_user_key(key)
+            # Don't freak out if user not found (they may have been removed)
+            if user
+              { key: key, deposits: deposits, user: user }
+            else
+              # Leave user undef and let the view work out what to do
+              { key: key, deposits: deposits }
             end
           end
         end
-
       end
     end
   end

--- a/app/views/hyrax/admin/stats/_deposits.html.erb
+++ b/app/views/hyrax/admin/stats/_deposits.html.erb
@@ -1,0 +1,9 @@
+<h3>Deposits By Users (<%= @presenter.date_filter_string %>)</h3>
+<ul>
+  <% @presenter.depositors.each do |usr| %>
+    <li>
+      <%= usr[:user] ? link_to( usr[:user], hyrax.user_path(usr[:user]), title: "View user's profile")  : "A removed user" %>
+      deposited <%= pluralize(usr[:deposits], "file") %>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
# Story

override depositor_summary.depositor to _not_ raise error if user is not found, also get stats/_depositor view to handle null user (i.e. removed user)

Refs #262

# Behavior Before Changes

admin/stats page throws error if a user who has once deposited is completely removed (via hyku admin)

# Expected Behavior After Changes

admin/stats page handles user who has once deposited is completely removed (via hyku admin)

The stats in the ''Deposits By Users'' section will show "A removed user deposited N files"

