### PR TITLE
Update iiif_print gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: d231525d2552a652e71292c919520f1e9e62a4cb
+  revision: 44d96c8e8e633ed56d286851648e9fbdf3feb880
   branch: main
   specs:
     iiif_print (1.0.0)


### PR DESCRIPTION
# Story

Bring in [iiif_print update with fix for manifest query](https://github.com/scientist-softserv/iiif_print/pull/229)
Refs #385 

# Expected Behavior Before Changes

Universal Viewer would spin and never resolve manifest. Manifest gave a 414 `Request-URI Too Long Error`
# Expected Behavior After Changes
Viewer displays manifests with > 200 pages

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-04-27 at 6 56 40 PM](https://user-images.githubusercontent.com/17851674/235038130-ab74a8cc-8306-47c6-a583-d2a0597bbb95.png)
</details>

# Notes