### PR TITLE
Adding pagination to items list

### DIFF
--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -3,7 +3,9 @@
  add license feature
 -->
 
-<% if presenter.member_presenters.present? %>
+<%  array_of_ids = presenter.list_of_item_ids_to_display %>
+<%  members = presenter.member_presenters_for(array_of_ids) %>
+<% if members.present? %>
   <div class="col-sm-12 work-show-items">
     <h2>Items:</h2>
     <table class="table table-striped related-files">
@@ -21,9 +23,16 @@
         </tr>
       </thead>
       <tbody>
-        <%= render partial: 'member', collection: presenter.member_presenters, locals: { parent_presenter: presenter } %>
+        <%= render partial: 'member', collection: members, locals: { parent_presenter: presenter } %>
       </tbody>
     </table>
+      <div class="row">
+    <% if presenter.total_pages > 1 %>
+        <div class="row record-padding col-md-9">
+          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+        </div><!-- /pager -->
+    <% end %>
+  </div>
   </div>
 <% elsif can? :edit, presenter.id %>
   <div class="alert alert-warning no-items-available" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>


### PR DESCRIPTION
# Story

Ref https://github.com/scientist-softserv/britishlibrary/issues/398

With the PDF splitting creating so many items on each work's show page, the metadata at the bottom of the page is almost impossible to get to.  Hyku's show pages include pagination, so this proposes adding pagination to the repo-specific partial as well. 

In addition to making the metadata more attainable, the loading of the show page will be much faster by only loading 10 items at a time.

# Expected Behavior Before Changes

A work's show page included a list of all of it's child works and filesets.
# Expected Behavior After Changes

A work's show page items list is limited to 10, with pagination options for the remainder. 
# Screenshots / Video

<details>
<summary></summary>

<img width="1074" alt="Screenshot 2023-04-28 at 11 44 11 AM" src="https://user-images.githubusercontent.com/17851674/235194197-704b6498-ea9d-42a3-befc-074f6fd767f6.png">
</details>

# Notes