### PR TITLE
Create new work type for child works

### DIFF
--- a/app/actors/hyrax/actors/pdf_page_actor.rb
+++ b/app/actors/hyrax/actors/pdf_page_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+module Hyrax
+  module Actors
+    class PdfPageActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/hyrax/pdf_pages_controller.rb
+++ b/app/controllers/hyrax/pdf_pages_controller.rb
@@ -1,0 +1,14 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+module Hyrax
+  # Generated controller for PdfPage
+  class PdfPagesController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::PdfPage
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = Hyrax::PdfPagePresenter
+  end
+end

--- a/app/forms/hyrax/pdf_page_form.rb
+++ b/app/forms/hyrax/pdf_page_form.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+module Hyrax
+  # Generated form for PdfPage
+  class PdfPageForm < Hyrax::Forms::WorkForm
+    self.model_class = ::PdfPage
+    self.terms += [:resource_type]
+  end
+end

--- a/app/indexers/concerns/iiif_print/child_indexer_decorator.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer_decorator.rb
@@ -1,0 +1,15 @@
+IiifPrint::ChildIndexer.module_eval do
+  def self.decorate_work_types!
+    Hyrax.config.curation_concerns.each do |work_type|
+      work_type.send(:include, IiifPrint::SetChildFlag) unless work_type.included_modules.include?(IiifPrint::SetChildFlag)
+      indexer = work_type.indexer
+      unless indexer.respond_to?(:iiif_print_lineage_service)
+        indexer.prepend(self)
+        indexer.class_attribute(:iiif_print_lineage_service, default: IiifPrint::LineageService)
+      end
+      if work_type.const_defined?(:GeneratedResourceSchema)
+        work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag)
+      end
+    end
+  end
+end

--- a/app/indexers/pdf_page_indexer.rb
+++ b/app/indexers/pdf_page_indexer.rb
@@ -1,0 +1,18 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+class PdfPageIndexer < Hyrax::WorkIndexer
+  # This indexes the default metadata. You can remove it if you want to
+  # provide your own metadata and indexing.
+  include Hyrax::IndexesBasicMetadata
+
+  # Fetch remote labels for based_near. You can remove this if you don't want
+  # this behavior
+  include Hyrax::IndexesLinkedMetadata
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  # def generate_solr_document
+  #  super.tap do |solr_doc|
+  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
+  #  end
+  # end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,7 +12,7 @@ class Article < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = ::ArticleIndexer

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -14,7 +14,7 @@ class Book < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = BookIndexer

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -12,7 +12,7 @@ class ConferenceItem < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = ConferenceItemIndexer

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -12,7 +12,7 @@ class Dataset < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = DatasetIndexer

--- a/app/models/exhibition_item.rb
+++ b/app/models/exhibition_item.rb
@@ -13,7 +13,7 @@ class ExhibitionItem < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = ExhibitionItemIndexer

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -15,7 +15,7 @@ class GenericWork < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/pdf_page.rb
+++ b/app/models/pdf_page.rb
@@ -1,21 +1,19 @@
-# frozen_string_literal: true
-
-class Image < ActiveFedora::Base
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+class PdfPage < ActiveFedora::Base
   include Hyrax::WorkBehavior
   include Ubiquity::UniversalMetadata
   include Ubiquity::SharedMetadata
   include Ubiquity::AllModelsVirtualFields
   include Ubiquity::WorksVirtualFields
+  include Ubiquity::VersionMetadataModelConcern
   # include Ubiquity::UpdateSharedIndex
   include Ubiquity::FileAvailabilityFaceting
-  # include ::Ubiquity::CachingSingle
+  # include Ubiquity::CachingSingle
   # Adds behaviors for hyrax-doi plugin.
   include Hyrax::DOI::DOIBehavior
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
-  include IiifPrint.model_configuration(
-    pdf_split_child_model: PdfPage
-  )
 
   property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: true do |index|
     index.as :stored_searchable
@@ -25,8 +23,12 @@ class Image < ActiveFedora::Base
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
 
-  self.indexer = ImageIndexer
+  self.indexer = PdfPageIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
+
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: PdfPage
+  )
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -12,7 +12,7 @@ class Report < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = ReportIndexer

--- a/app/models/thesis_or_dissertation.rb
+++ b/app/models/thesis_or_dissertation.rb
@@ -15,7 +15,7 @@ class ThesisOrDissertation < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = ThesisOrDissertationIndexer

--- a/app/presenters/hyrax/pdf_page_presenter.rb
+++ b/app/presenters/hyrax/pdf_page_presenter.rb
@@ -1,0 +1,10 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+module Hyrax
+  class PdfPagePresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
+    include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
+    include Hyrax::DOI::DataCiteDOIPresenterBehavior
+  end
+end

--- a/app/views/hyrax/pdf_pages/_pdf_page.html.erb
+++ b/app/views/hyrax/pdf_pages/_pdf_page.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: pdf_page, document_counter: pdf_page_counter  %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -18,6 +18,8 @@ Hyrax.config do |config|
   # Injected via `rails g hyrax:work TimeBasedMedia`
   config.register_curation_concern :time_based_media
   config.register_curation_concern :generic_work
+  # Injected via `rails g hyrax:work PdfPage`
+  config.register_curation_concern :pdf_page
 
   # Email recipient of messages sent via the contact form
   # This is set by account settings

--- a/config/locales/pdf_page.de.yml
+++ b/config/locales/pdf_page.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        description:        "Pdf page Werke"
+        name:               "Pdf Page"

--- a/config/locales/pdf_page.en.yml
+++ b/config/locales/pdf_page.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        description:        "Pdf page works"
+        name:               "Pdf Page"

--- a/config/locales/pdf_page.es.yml
+++ b/config/locales/pdf_page.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        # TODO: translate `human_name` into Spanish
+        description:        "Pdf page trabajos"
+        name:               "Pdf Page"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/pdf_page.fr.yml
+++ b/config/locales/pdf_page.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        description:        "Pdf page œuvres"
+        name:               "Pdf Page"

--- a/config/locales/pdf_page.it.yml
+++ b/config/locales/pdf_page.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        description:        "Pdf page opere"
+        name:               "Pdf Page"

--- a/config/locales/pdf_page.pt-BR.yml
+++ b/config/locales/pdf_page.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        description:        "Pdf page trabalhos"
+        name:               "Pdf Page"

--- a/config/locales/pdf_page.zh.yml
+++ b/config/locales/pdf_page.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      pdf_page:     'fa fa-file-text-o'
+    select_type:
+      pdf_page:
+        # TODO: translate `human_name` into Chinese
+        description:        "Pdf page 作品"
+        name:               "Pdf Page"
+        # TODO: translate `human_name` into Chinese

--- a/spec/controllers/hyrax/pdf_pages_controller_spec.rb
+++ b/spec/controllers/hyrax/pdf_pages_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+require 'rails_helper'
+
+RSpec.describe Hyrax::PdfPagesController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/features/create_pdf_page_spec.rb
+++ b/spec/features/create_pdf_page_spec.rb
@@ -1,0 +1,69 @@
+# Generated via
+#  `rails generate hyrax:work PdfPage`
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a PdfPage', js: false do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      # If you generate more than one work uncomment these lines
+      # choose "payload_concern", option: "PdfPage"
+      # click_button "Create work"
+
+      expect(page).to have_content "Add New Pdf page"
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('span#addfiles') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      select('In Copyright', from: 'Rights statement')
+
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+      choose('pdf_page_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      check('agreement')
+
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+    end
+  end
+end


### PR DESCRIPTION
Refs #387 

# Expected Behavior Before Changes
When a PDF is attached to a work, the child work would be split into a work type
of self.
# Expected Behavior After Changes
With these changes, the work types with a PDF attached will be
split into a work type of PdfPage.
# Screenshots / Video
![Screenshot 2023-04-28 at 9 05 16 AM](https://user-images.githubusercontent.com/95306716/235199254-3af50a0e-3d89-4464-ae6d-eb7ad199f507.png)
