### PR TITLE
Guard for empty funder award

### DIFF
--- a/app/iiif_print/metadata_decorator.rb
+++ b/app/iiif_print/metadata_decorator.rb
@@ -64,9 +64,9 @@ module IiifPrint
         result = []
         hashes.each do |hash|
           funder_name = hash['funder_name']
-          funder_awards = hash['funder_award'].join(' | ')
+          funder_awards = hash['funder_award']&.join(' | ')
           result << apply_label('Name', funder_name)
-          result << apply_label('Awards', funder_awards)
+          result << apply_label('Awards', funder_awards) if funder_awards
         end
 
         result


### PR DESCRIPTION
# Story

Universal viewer was failing when there was a funder but no funder award.

# Expected Behavior Before Changes

# Expected Behavior After Changes

Manifest build correctly with or without funder awards.

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes