### PR TITLE
i330 - update field mapping to be in an array

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -153,7 +153,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
       'publisher' => { from: ['publisher'] },
       'qualification_level' => { from: ['qualification_level'] },
       'qualification_name' => { from: ['qualification_name'] },
-      'record_level_file_version_declaration' => { from: 'file_declaration' },
+      'record_level_file_version_declaration' => { from: ['file_declaration'] },
       'refereed' => { from: ['peer_reviewed'] },
       'related_exhibition' => { from: ['related_exhibition'] },
       'related_exhibition_date' => { from: ['related_exhibition_date'] },


### PR DESCRIPTION
ref: https://github.com/scientist-softserv/britishlibrary/issues/330

In client QA, Graham noticed that the exported header was simply an "f" instead of the full name "file declaration": 

Exported sample file from staging: 
[export__from_all_1.csv](https://github.com/scientist-softserv/britishlibrary/files/11384920/export__from_all_1.csv)

<img width="381" alt="image" src="https://user-images.githubusercontent.com/10081604/235983561-4db943a0-2075-4539-b360-ab8a67af2d09.png">


ref slack convo: https://assaydepot.slack.com/archives/C0313NK2LJ0/p1683124610866229

To resolve this, we needed to update the bulkrax field mapping to be an array. Bulkrax asks for[ [from].first](https://github.com/samvera-labs/bulkrax/blob/main/app/models/bulkrax/csv_entry.rb#L267) when setting its parsed_metadata which, because it wasn't an array, took the first letter of "file_declaration".

It now exports the following sample file: 
[export__from_all_1 3.csv](https://github.com/scientist-softserv/britishlibrary/files/11384917/export__from_all_1.3.csv)

<img width="369" alt="image" src="https://user-images.githubusercontent.com/10081604/235983418-8f7335e3-e544-4905-a62b-15c95b74a820.png">
