### PR TITLE
revert non-op change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,4 +152,4 @@ gem 'sidekiq'
 gem 'tether-rails'
 gem 'validate_url'
 gem 'hyrax-v2_graph_indexer', "~> 0.3", git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer.git', ref: 'e8b5976c6aa91ac18af8b29acb949e8f30152c2d'
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: "18e4826bcb0caec6b8ebf74d0b9ec407c398e995"
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '18e4826bcb0caec6b8ebf74d0b9ec407c398e995'


### PR DESCRIPTION
debugging pipeline issue. We noticed that the pipeline didn't run when a PR got merged into main, and since then the deploys have failed.

ref slack convo: https://assaydepot.slack.com/archives/G030UPFBT2S/p1683302066383189

Main eventually built and deployed successfully to staging with the non-op change. I simply changed single quotes to double quotes in the Gemfile. This PR is resetting it back to single quotes. Both iterations should be non-impacting to the code and application itself and is not the reason why it suddenly succeeded. 🙃 



