### PR TITLE
Allow signed out users to access child works

### DIFF
--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -2,14 +2,14 @@
 
 <tr class="<%= dom_class(member) %> attributes">
   <td class="thumbnail">
-    <% if user_signed_in? %>
+    <% if user_signed_in? || member.human_readable_type != 'File' %>
       <%= render_thumbnail_tag member %>
     <% else %>
       <%= render_thumbnail_tag member, {}, { href: hyrax.download_path(member.id) } %>
     <% end %>
   </td>
   <td class="attribute attribute-filename ensure-wrapped">
-    <% if user_signed_in? %>
+    <% if user_signed_in? || member.human_readable_type != 'File' %>
       <%= link_to(member.link_name, contextual_path(member, @presenter)) %>
     <% else %>
       <%= link_to(member.link_name, hyrax.download_path(member.id), target: :_blank) %>


### PR DESCRIPTION
This commit adds an additional condition to check if the presenter (member) is a FileSet or not.  If it is not a FileSet then the download link should NOT render.

# Story

Public users (those that are not logged in) will be able to click on a child work and not get an error.

Refs #404 

# Expected Behavior Before Changes

Public users would get an error if they click on a child work.

# Expected Behavior After Changes

Public users would navigate to the child work when clicking on the child work link.

# Screenshots / Video

![bl-404](https://github.com/scientist-softserv/britishlibrary/assets/19597776/16742dab-0d07-460d-a27a-4643a4b8c27e)
