### PR TITLE
Add a check to see it is a thesis or dissertation

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -44,7 +44,12 @@ module Hyku
 
     def date_accepted
       return if solr_document["date_accepted_tesim"]&.join.blank?
+      return thesis_or_disseration_date_accepted if solr_document.human_readable_type == "Thesis Or Dissertation"
 
+      solr_document["date_accepted_tesim"]
+    end
+
+    def thesis_or_disseration_date_accepted
       solr_document["date_accepted_tesim"].map { |d| Ubiquity::ParseDate.return_date_part(d, "year") }
     end
 

--- a/spec/presenters/hyku/work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/work_show_presenter_spec.rb
@@ -123,35 +123,75 @@ RSpec.describe Hyku::WorkShowPresenter do
   end
 
   describe "#date_accepted" do
-    context "when date_accepted is in YYYY format" do
-      let(:document) { { "date_accepted_tesim" => ["2023"] } }
+    context "when the SolrDocument is not a Thesis Or Dissertation" do
+      context "when date_accepted is in YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["2023"] } }
 
-      it "returns the formatted date" do
-        expect(presenter.date_accepted).to eq(["2023"])
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["2023"])
+        end
+      end
+
+      context "when date_accepted is in YYYY-MM-DD format" do
+        let(:document) { { "date_accepted_tesim" => ["2023-12-13"] } }
+
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["2023-12-13"])
+        end
+      end
+
+      context "when date_accepted is in MM/DD/YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["12/13/2023"])
+        end
+      end
+
+      context "when date_accepted is not valid" do
+        let(:document) { { "date_accepted_tesim" => [""] } }
+
+        it "returns nil" do
+          expect(presenter.date_accepted).to be nil
+        end
       end
     end
 
-    context "when date_accepted is in YYYY-MM-DD format" do
-      let(:document) { { "date_accepted_tesim" => ["2023-12-13"] } }
-
-      it "returns the formatted date" do
-        expect(presenter.date_accepted).to eq(["2023"])
+    context "when the SolrDocument is a Thesis Or Dissertation" do
+      before do
+        allow(solr_document).to receive(:human_readable_type).and_return("Thesis Or Dissertation")
       end
-    end
 
-    context "when date_accepted is in MM/DD/YYYY format" do
-      let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+      context "when date_accepted is in YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["2023"] } }
 
-      it "returns the formatted date" do
-        expect(presenter.date_accepted).to eq(["2023"])
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["2023"])
+        end
       end
-    end
 
-    context "when date_accepted is not valid" do
-      let(:document) { { "date_accepted_tesim" => [""] } }
+      context "when date_accepted is in YYYY-MM-DD format" do
+        let(:document) { { "date_accepted_tesim" => ["2023-12-13"] } }
 
-      it "returns nil" do
-        expect(presenter.date_accepted).to be nil
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["2023"])
+        end
+      end
+
+      context "when date_accepted is in MM/DD/YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+
+        it "returns the formatted date" do
+          expect(presenter.date_accepted).to eq(["2023"])
+        end
+      end
+
+      context "when date_accepted is not valid" do
+        let(:document) { { "date_accepted_tesim" => [""] } }
+
+        it "returns nil" do
+          expect(presenter.date_accepted).to be nil
+        end
       end
     end
   end


### PR DESCRIPTION
This commit will add a check to see if the work is a thesis or dissertation.  If it is, then the date will be modified to only show the year.  If not, then it will display whatever date is entered.

# Story

All work types are not showing only the year in the `date_accepted` field. when only the Thesis or Dissertation work type should exhibit this behavior.

Refs #179 

# Expected Behavior Before Changes

All work types were showing only the year in the `date_accepted` field.

# Expected Behavior After Changes

Only the Thesis Or Dissertation work type should display the `date_accepted` as only the year.

# Screenshots / Video

Example of a Book Contribution:
<img width="751" alt="image" src="https://github.com/scientist-softserv/britishlibrary/assets/19597776/edf3c837-dc05-4a8e-b26d-14c25e1e952f">

Example of a Thesis Or Dissertation:
<img width="734" alt="image" src="https://github.com/scientist-softserv/britishlibrary/assets/19597776/b3c3bc2d-e838-4284-805f-b8fe248bcc25">
