### PR TITLE
Fix plan S Flag

### DIFF
--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -11,7 +11,7 @@ class OpenAccessService
     # Scholarly articles
     when Article, ConferenceItem, GenericWork
       return true if peer_reviewed? &&
-                     work.record_level_file_version_declaration &&
+                     work.record_level_file_version_declaration == '1' &&
                      public_files?(max_embargo_mths: 0) &&
                      coalition_s?
     # Books


### PR DESCRIPTION
# Story
Rework to fix logic so the `record level file version declaration flag` works correctly.

Refs #331 

# Expected Behavior Before Changes

Unchecked flag still resulted in `OpenAccess` showing in the OAI feed.

# Expected Behavior After Changes

OAI feed correctly does not show `OpenAccess` unless flag is checked.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-05-10 at 1 51 33 PM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/fb4aa273-d262-412b-acac-f4573d949100)
</details>

# Notes