### PR TITLE
I387 set is child default value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,4 +152,4 @@ gem 'sidekiq'
 gem 'tether-rails'
 gem 'validate_url'
 gem 'hyrax-v2_graph_indexer', "~> 0.3", git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer.git', ref: 'e8b5976c6aa91ac18af8b29acb949e8f30152c2d'
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: "18e4826bcb0caec6b8ebf74d0b9ec407c398e995"
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,8 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 18e4826bcb0caec6b8ebf74d0b9ec407c398e995
-  ref: 18e4826bcb0caec6b8ebf74d0b9ec407c398e995
+  revision: fd5b6678a620d32c97239aef01141190051277fd
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
@@ -137,6 +136,7 @@ GIT
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
+      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -413,6 +413,9 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.4.4)
+    disposable (0.6.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      representable (>= 3.1.1, < 4)
     docile (1.4.0)
     docopt (0.5.0)
     draper (4.0.2)
@@ -1007,6 +1010,13 @@ GEM
       redis (>= 3.0.4)
     redlock (1.2.2)
       redis (>= 3.0.0, < 5.0)
+    reform (2.6.2)
+      disposable (>= 0.5.0, < 1.0.0)
+      representable (>= 3.1.1, < 4)
+      uber (< 0.2.0)
+    reform-rails (0.2.3)
+      activemodel (>= 5.0)
+      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.1.1)
     representable (3.1.1)
       declarative (< 0.1.0)

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -8,15 +8,6 @@ IiifPrint.config do |config|
   #
   config.excluded_model_name_solr_field_values = ['Pdf Page']
 
-  config.child_work_attributes_function = lambda do |parent_work:, admin_set_id:|
-    {
-      admin_set_id: admin_set_id.to_s,
-      creator: parent_work.creator.to_a,
-      rights_statement: parent_work.rights_statement.to_a,
-      visibility: parent_work.visibility.to_s, 
-      is_child: true
-    }
-  end
   # Add configurable solr field key for searching,
   # default key is: 'human_readable_type_sim'
   # if another key is used, make sure to adjust the

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -8,6 +8,15 @@ IiifPrint.config do |config|
   #
   config.excluded_model_name_solr_field_values = ['Pdf Page']
 
+  config.child_work_attributes_function = lambda do |parent_work:, admin_set_id:|
+    {
+      admin_set_id: admin_set_id.to_s,
+      creator: parent_work.creator.to_a,
+      rights_statement: parent_work.rights_statement.to_a,
+      visibility: parent_work.visibility.to_s, 
+      is_child: true
+    }
+  end
   # Add configurable solr field key for searching,
   # default key is: 'human_readable_type_sim'
   # if another key is used, make sure to adjust the


### PR DESCRIPTION
# Story
iiif_print ref: https://github.com/scientist-softserv/iiif_print/pull/237
Refs #387 

# Story

This PR is to address the feedback from the following ticket. The user was still able to see the child works in the recent works catalog and recent works section, while they were processing. This is because they weren't getting filtered out until the relationship job are formed, and the is_child property was set. 

To resolve this, we are setting the child work is_child attribute to be true on default in iiif_print. So this PR updates the gem to pull in the fix.  

Refs https://github.com/scientist-softserv/britishlibrary/issues/387

# Expected Behavior Before Changes
ref: https://github.com/scientist-softserv/britishlibrary/issues/387#issuecomment-1542771258

![Screenshot 2023-05-11 at 17-07-15 Index Catalog __ Hyku](https://github.com/scientist-softserv/britishlibrary/assets/10081604/dc35841b-0144-499a-9a88-ac0fe3e8d33a)
![Screenshot 2023-05-11 at 17-07-04 Hyku](https://github.com/scientist-softserv/britishlibrary/assets/10081604/046c79af-279e-4b11-bac5-3505118550a9)



# Expected Behavior After Changes

As a result, you cannot see the child records while it's still processing. The user should and does not see child works in the following scenarios: 

## EMPTY CATALOG SEARCH :
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/214197ba-8888-411c-aa65-235baf78619e)

## RECENT WORKS SECTION: 
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/84348636-b2d4-48b0-a37d-305570baada4)

## VIEW RECENT ADDITIONS CATALOG PG: 
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/12017ebd-0e1d-4a98-b84f-a0345cbaee44)


## Sidekiq
Notice is_child property is being set to true in the CreateWorkJob: 

![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/a7638aa9-dd30-4b3f-ac9c-d247b78e9bbc)

sample work: [service-rbc-rbc0001-2015-2015gen56010-2015gen56010.pdf](https://github.com/scientist-softserv/iiif_print/files/11456897/service-rbc-rbc0001-2015-2015gen56010-2015gen56010.pdf)

# Notes