### PR TITLE
[i412] - FIX: normalize data input for record_level_file_version_decl…

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -28,6 +28,7 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc[Solrizer.solr_name('account_cname')] = Site.instance&.account&.cname
       solr_doc['account_institution_name_ssim'] = "#{Site.instance.institution_name} Research Repository"
       solr_doc['open_access_determination_ssim'] = object.open_access_determination
+      solr_doc['record_level_file_version_declaration_bsi'] = object.record_level_file_version_declaration
     end
   end
 end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -28,7 +28,7 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc[Solrizer.solr_name('account_cname')] = Site.instance&.account&.cname
       solr_doc['account_institution_name_ssim'] = "#{Site.instance.institution_name} Research Repository"
       solr_doc['open_access_determination_ssim'] = object.open_access_determination
-      solr_doc['record_level_file_version_declaration_bsi'] = object.record_level_file_version_declaration
+      solr_doc['record_level_file_version_declaration_bsi'] = object.try(:record_level_file_version_declaration)
     end
   end
 end

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -8,6 +8,7 @@ module Bulkrax::HasLocalProcessing
     parsed_metadata['resource_type'] = ['ThesisOrDissertation Doctoral thesis'] if parser.is_a? Bulkrax::XmlEtdDcParser
     parsed_metadata['creator_search'] = parsed_metadata&.[]('creator_search')&.map { |c| c.values.join(', ') }
     parsed_metadata["qualification_name"] = set_qualification_name if parsed_metadata["qualification_name"]
+    parsed_metadata['record_level_file_version_declaration'] = ActiveModel::Type::Boolean.new.cast parsed_metadata['record_level_file_version_declaration']
     set_institutional_relationships
 
     ['funder', 'creator', 'contributor', 'editor', 'alternate_identifier', 'related_identifier', 'current_he_institution'].each do |key|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -86,7 +86,7 @@ class SolrDocument
   attribute :collection_names, Solr::Array, solr_name('collection_names')
   attribute :collection_id, Solr::Array, solr_name('collection_id')
   attribute :ethos_access_rights, Solr::Array, solr_name('ethos_access_rights')
-  attribute :record_level_file_version_declaration, Solr::String, solr_name('record_level_file_version_declaration')
+  attribute :record_level_file_version_declaration, Solr::String, 'record_level_file_version_declaration_bsi'
   attribute :open_access_determination, Solr::String, 'open_access_determination_ssim'
 
   field_semantics.merge!(

--- a/app/services/open_access_service.rb
+++ b/app/services/open_access_service.rb
@@ -11,7 +11,7 @@ class OpenAccessService
     # Scholarly articles
     when Article, ConferenceItem, GenericWork
       return true if peer_reviewed? &&
-                     work.record_level_file_version_declaration == '1' &&
+                     ActiveModel::Type::Boolean.new.cast(work.record_level_file_version_declaration) &&
                      public_files?(max_embargo_mths: 0) &&
                      coalition_s?
     # Books

--- a/app/views/hyrax/base/_form_declaration.html.erb
+++ b/app/views/hyrax/base/_form_declaration.html.erb
@@ -1,4 +1,4 @@
 <% if curation_concern.respond_to?(:record_level_file_version_declaration) %>
-  <% checked = true if curation_concern.record_level_file_version_declaration == '1' %>
+  <% checked = ActiveModel::Type::Boolean.new.cast(curation_concern.record_level_file_version_declaration) %>
   <%= f.input :record_level_file_version_declaration, as: :boolean, label: t('hyrax.base.form_files.record_level_file_version_declaration_question', model: curation_concern.class), input_html: { checked: checked } %>
 <% end %>


### PR DESCRIPTION
RESOLVES:
- https://github.com/scientist-softserv/britishlibrary/issues/412

# Story

This PR will allow for users to import CSVs using boolean values for the file_declaration field.

Refs #412

# Expected Behavior After Changes
![Screenshot 2023-05-12 at 10 52 55 AM](https://github.com/scientist-softserv/britishlibrary/assets/10081604/aba8957a-f40e-48e8-8207-3de0dc687c8e)
![Screenshot 2023-05-12 at 10 52 20 AM](https://github.com/scientist-softserv/britishlibrary/assets/10081604/eef934f5-4dc9-4022-a2da-c338b19b5021)
![Screenshot 2023-05-12 at 10 52 25 AM](https://github.com/scientist-softserv/britishlibrary/assets/10081604/6d6481aa-c47b-4545-b848-8bc1bce7e126)
![Screenshot 2023-05-12 at 10 52 29 AM](https://github.com/scientist-softserv/britishlibrary/assets/10081604/db76c1b9-5e85-46f9-af49-95e6fcea14bc)

