### PR TITLE
candidate for #380 

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -31,9 +31,7 @@ module Hyrax
     # OVERRIDE Hyrax 2.9.6 for IRUS Analytics
     def item_identifier_for_irus_analytics
       # return the OAI identifier
-      # We must send the parent work id to IRUS otherwise it gets confused
-      parent_work_id = helpers.work_id_from_file_set_id(params[:id])
-      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
+      helpers.oai_identifier(self, params[:id])
     end
 
     private

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -29,7 +29,12 @@ module Hyrax
     # OVERRIDE Hyrax 2.9.6 for IRUS Analytics
     def item_identifier_for_irus_analytics
       # return the OAI identifier
-      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+      # We must send the parent work id to IRUS otherwise it gets confused
+      # This works but hits fcrepo twice :/
+      parent_work_id = ActiveFedora::Base.find(params[:id]).parent.id
+
+      #"#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
     end
 
     private

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -6,6 +6,8 @@ module Hyrax
     include Hyrax::LocalFileDownloadsControllerBehavior
     include IrusAnalytics::Controller::AnalyticsBehaviour
 
+    helper Hyrax::IrusHelper
+
     def self.default_content_path
       :original_file
     end
@@ -30,10 +32,7 @@ module Hyrax
     def item_identifier_for_irus_analytics
       # return the OAI identifier
       # We must send the parent work id to IRUS otherwise it gets confused
-      # This works but hits fcrepo twice :/
-      parent_work_id = ActiveFedora::Base.find(params[:id]).parent.id
-
-      #"#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+      parent_work_id = helpers.work_id_from_file_set_id(params[:id])
       "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
     end
 

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -80,7 +80,13 @@ module Hyrax
     def item_identifier_for_irus_analytics
       # return the OAI identifier
       # http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
-      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+
+      # We must send the parent work id to IRUS otherwise it gets confused
+      # This works but hits fcrepo twice :/
+      parent_work_id = ActiveFedora::Base.find(params[:id]).parent.id
+
+      #"#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
     end
 
     def skip_send_irus_analytics?(usage_event_type)

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -14,6 +14,8 @@ module Hyrax
 
     # provides the help_text view method
     helper PermissionsHelper
+    # IRUS helper
+    helper Hyrax::IrusHelper
 
     helper_method :curation_concern
     copy_blacklight_config_from(::CatalogController)
@@ -80,12 +82,8 @@ module Hyrax
     def item_identifier_for_irus_analytics
       # return the OAI identifier
       # http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
-
       # We must send the parent work id to IRUS otherwise it gets confused
-      # This works but hits fcrepo twice :/
-      parent_work_id = ActiveFedora::Base.find(params[:id]).parent.id
-
-      #"#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{params[:id]}"
+      parent_work_id = helpers.work_id_from_file_set_id(params[:id])
       "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
     end
 

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -82,9 +82,7 @@ module Hyrax
     def item_identifier_for_irus_analytics
       # return the OAI identifier
       # http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
-      # We must send the parent work id to IRUS otherwise it gets confused
-      parent_work_id = helpers.work_id_from_file_set_id(params[:id])
-      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(self)}:#{parent_work_id}"
+      helpers.oai_identifier(self, params[:id])
     end
 
     def skip_send_irus_analytics?(usage_event_type)

--- a/app/helpers/hyrax/irus_helper.rb
+++ b/app/helpers/hyrax/irus_helper.rb
@@ -2,8 +2,13 @@
 
 module Hyrax
   module IrusHelper
+    def oai_identifier(controller, file_set_id)
+      "#{CatalogController.blacklight_config.oai[:provider][:record_prefix].call(controller)}:#{work_id_from_file_set_id(file_set_id)}"
+    end
+
     def work_id_from_file_set_id(file_set_id)
-      parent_for(ActiveFedora::Base.where(id: file_set_id).first).id
+      file_set = ActiveFedora::Base.where(id: file_set_id)&.first
+      parent_for(file_set)&.id
     end
 
     def parent_for(file_set)

--- a/app/helpers/hyrax/irus_helper.rb
+++ b/app/helpers/hyrax/irus_helper.rb
@@ -2,7 +2,6 @@
 
 module Hyrax
   module IrusHelper
-
     def work_id_from_file_set_id(file_set_id)
       parent_for(ActiveFedora::Base.where(id: file_set_id).first).id
     end
@@ -10,6 +9,5 @@ module Hyrax
     def parent_for(file_set)
       file_set.parent || file_set.member_of.find(&:work?)
     end
-
   end
 end

--- a/app/helpers/hyrax/irus_helper.rb
+++ b/app/helpers/hyrax/irus_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module IrusHelper
+
+    def work_id_from_file_set_id(file_set_id)
+      parent_for(ActiveFedora::Base.where(id: file_set_id).first).id
+    end
+
+    def parent_for(file_set)
+      file_set.parent || file_set.member_of.find(&:work?)
+    end
+
+  end
+end


### PR DESCRIPTION
tl;dr Does what is required, but could perhaps be more efficient about it

# Story

IRUS sends work if when work id "investigated" `SharedBehaviorsController` u! :p  
a file_set id when file_set is "investigated" `FileSetsController` 
and file_set id when a file is "requested"  `DownloadsController`

but according to #380 IRUS considers these a single thing and is confounded by different IDs

# Expected Behavior Before Changes

Send IDs as above

# Expected Behavior After Changes

Send only the work id for works, file_sets and downloads

# Notes

To achieve the above I have used `AcitveFedora::Base.find(params[:id]).parent.id` This works, but hits fcrepo TWICE.

Happy to be availed of a nice way to do this :) 