### PR TITLE
Have `Ubiquity::ParseDate` handle month and year

### DIFF
--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -19,19 +19,11 @@ module Ubiquity
       return nil if date.blank?
       return date if date_part == 'year' && date.match(/^\d{4}$/)
 
-      begin
-        parsed_date = date =~ %r{\d{1,2}/\d{1,2}/\d{4}} ? Date.strptime(date, '%m/%d/%Y') : Date.parse(date)
-      rescue ArgumentError
-        parsed_date = nil
-      end
+      parsed_date = parse_date_by_format(date)
 
       return nil if parsed_date.nil?
 
-      case date_part
-      when 'year'  then parsed_date.strftime("%Y")
-      when 'month' then parsed_date.strftime("%m")
-      when 'day'   then parsed_date.strftime("%d")
-      end
+      extract_date_part(parsed_date, date, date_part)
     end
 
     def self.transform_published_date_group(date_published_hash)
@@ -50,16 +42,45 @@ module Ubiquity
 
     private
 
+    def self.parse_date_by_format(date)
+      case date
+      when /^\d{4}-\d{2}$/ then Date.strptime(date, '%Y-%m') # 'YYYY-MM' format
+      when /^\d{1,2}\/\d{4}$/ then Date.strptime(date, '%m/%Y') # 'MM/YYYY' format
+      when %r{\d{1,2}/\d{1,2}/\d{4}} then Date.strptime(date, '%m/%d/%Y') # 'MM/DD/YYYY' format
+      else
+        Date.parse(date) rescue nil
+      end
+    end
+
+    def self.extract_date_part(parsed_date, original_date, date_part)
+      case date_part
+      when 'year'  then parsed_date.strftime("%Y")
+      when 'month' then parsed_date.strftime("%m")
+      when 'day'   then day_part(parsed_date, original_date)
+      end
+    end
+
+    def self.day_part(parsed_date, original_date)
+      if parsed_date.day == 1 && (original_date.match(/^\d{4}-\d{2}$/) || original_date.match(/^\d{1,2}\/\d{4}$/))
+        nil
+      else
+        parsed_date.strftime("%d")
+      end
+    end
+
     def transform_date_group(date)
       date_parts =  date.split('-')
       year = "#{date_field}_year"
       month = "#{date_field}_month"
       day = "#{date_field}_day"
-      if date_parts.count > 2
+      if date_parts.count == 2
+        #returns a hash in the form {"date_published_year"=>"2017", "date_published_month"=>"02"}
+        Hash[[ [year,  date_parts.first], [month,  date_parts.last] ]]
+      elsif date_parts.count > 2
         #returns a hash in the form {"date_published_year"=>"2017", "date_published_month"=>"02", "date_published_day"=>"02"}
         Hash[[ [year,  date_parts.first], [month,  date_parts[1]], [day,  date_parts.last]  ]]
       else
-        Hash[[ [year,  date_parts.first], [month,  date_parts[1]] ]]
+        Hash[[ [year,  date_parts.first] ]]
       end
     end
   end

--- a/spec/services/ubiquity/parse_date_spec.rb
+++ b/spec/services/ubiquity/parse_date_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe Ubiquity::ParseDate do
       expect(described_class.return_date_part(date, 'day')).to eq('13')
     end
 
+    it 'handles MM/YYYY' do
+      date = '12/2023'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to eq('12')
+      expect(described_class.return_date_part(date, 'day')).to be_nil
+    end
+
+    it 'handles YYYY-MM' do
+      date = '2023-12'
+      expect(described_class.return_date_part(date, 'year')).to eq('2023')
+      expect(described_class.return_date_part(date, 'month')).to eq('12')
+      expect(described_class.return_date_part(date, 'day')).to be_nil
+    end
+
     it 'returns nil for invalid dates' do
       date = 'invalid_date'
       expect(described_class.return_date_part(date, 'year')).to be_nil


### PR DESCRIPTION
This commit will allow the handling of the cases when you are given only a month and a year.  The format it is expecting is `YYYY-MM` or `MM/YYYY`.

# Story

Refs #409 

# Expected Behavior Before Changes

Any date that is incomplete will not be parsed back into the form after initial save which puts it at risk at being wiped for subsequent saves 

# Expected Behavior After Changes

Dates can be saved as YYYY, YYYY-MM or YYYY-MM-DD, when returning to the form the expected date is present

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes

Not my work, all @kirkkwang 