### PR TITLE
ensure email is removed from hidden inputs in remove form

### DIFF
--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -77,7 +77,7 @@
                       <td>
                         <%# For the remove button form, add all admin emails *except this one* as hidden inputs %>
                         <%= simple_form_for @account, url: [:proprietor, @account], namespace: "remove_#{email}_form", html: { class: 'form' } do |f| %>
-                          <% keep_emails = @account.admin_emails - [ email ] %>
+                          <% keep_emails = @account.admin_emails - [ email.to_s ] %>
                           <% if keep_emails.empty? %>
                             <%= f.input_field :admin_emails, multiple: true, hidden: true, value: '' %>
                           <% else %>


### PR DESCRIPTION
# Story

Refs #240 

# Expected Behaviour Before Changes

Click on "remove" button next to an admin user on proprietor/accounts/1 the page reloads with success message but user is still an admin

# Expected Behaviour After Changes

Click on "remove" button next to an admin user on proprietor/accounts/1 the page reloads with success message and the user is no longer an admin


# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes