### PR TITLE
🎁 Amend text for plan s

### DIFF
--- a/app/views/hyrax/base/_form_declaration.html.erb
+++ b/app/views/hyrax/base/_form_declaration.html.erb
@@ -1,4 +1,4 @@
 <% if curation_concern.respond_to?(:record_level_file_version_declaration) %>
   <% checked = ActiveModel::Type::Boolean.new.cast(curation_concern.record_level_file_version_declaration) %>
-  <%= f.input :record_level_file_version_declaration, as: :boolean, label: t('hyrax.base.form_files.record_level_file_version_declaration_question', model: curation_concern.class), input_html: { checked: checked } %>
+  <%= f.input :record_level_file_version_declaration, as: :boolean, label: t('hyrax.base.form_files.record_level_file_version_declaration_question'), input_html: { checked: checked } %>
 <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -326,7 +326,7 @@ en:
           accommodate your request. If you experience errors uploading from the
           cloud, let us know via the %{contact_href}.</p>
         local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
-        record_level_file_version_declaration_question: Does %{model} include non-restricted use file?
+        record_level_file_version_declaration_question: Is at least one file unrestricted (open access)?
       form_member_of_collections:
         actions:
           remove: Remove from collection


### PR DESCRIPTION
This commit will update restricted use question and remove the model
type from the associated partial

# Story

Refs #421

# Expected Behavior Before Changes
When adding a file to a specific work type, the question "Does %{model} include non-restricted use file?" was being displayed.

# Expected Behavior After Changes
When adding a file to a specific work type, the question "Is at least one file unrestricted (open access)?" is rendered.

# Screenshots / Video
![Screenshot 2023-05-16 at 10 51 33 AM](https://github.com/scientist-softserv/britishlibrary/assets/95306716/193a2306-b279-47ef-9c1c-1683f5302a40)
