### PR TITLE
I401 pdf split missing page relationships

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: fd5b6678a620d32c97239aef01141190051277fd
+  revision: 8fdf56e151b5adb7e6aab1cd29d39b74554ed48a
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -6,14 +6,14 @@ IiifPrint.config do |config|
   # @example
   #   # config.excluded_model_name_solr_field_values = ['Generic Work', 'Image']
   #
-  config.excluded_model_name_solr_field_values = ['Pdf Page']
+  # config.excluded_model_name_solr_field_values = ['Pdf Page']
 
   # Add configurable solr field key for searching,
   # default key is: 'human_readable_type_sim'
   # if another key is used, make sure to adjust the
   # config.excluded_model_name_solr_field_values to match
   # @example
-  #   config.excluded_model_name_solr_field_key = 'some_solr_field_key'
+  # config.excluded_model_name_solr_field_key = 'human_readable_type_tesim'
 
   config.default_iiif_manifest_version = 3
 

--- a/db/migrate/20230517213013_initial_load_plan_s_funders.rb
+++ b/db/migrate/20230517213013_initial_load_plan_s_funders.rb
@@ -1,0 +1,14 @@
+class InitialLoadPlanSFunders < ActiveRecord::Migration[5.2]
+  def up
+    MaintainPlanSFunders.call
+  end
+
+  def down
+    @updated_funder_dois = []
+    PlanSFunder.find_each do |funder|
+      funder.update(funder_status: 'inactive')
+      @updated_funder_dois << funder.funder_doi
+    end
+    ReindexFundersJob.perform_later(dois: @updated_funder_dois)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_03_180646) do
+ActiveRecord::Schema.define(version: 2023_05_17_213013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/funders.rake
+++ b/lib/tasks/funders.rake
@@ -6,8 +6,19 @@ namespace :hyku do
     MaintainPlanSFunders.call
   end
 
+  desc "empty and reload PlanSFunder table"
   task reset_funders: :environment do
     PlanSFunder.destroy_all
     MaintainPlanSFunders.call
+  end
+
+  desc "deactive PlanSFunders and reindex works"
+  task clear_funders: :environment do
+    @updated_funder_dois = []
+    PlanSFunder.find_each do |funder|
+      funder.update(funder_status: 'inactive')
+      @updated_funder_dois << funder.funder_doi
+    end
+    ReindexFundersJob.perform_later(dois: @updated_funder_dois)
   end
 end


### PR DESCRIPTION
# Story

This PR addresses two tickets:
- #401 
- #420 

# Expected Behavior Before Changes

- PDF splits did not get appropriate relationships when a parent work included more than one PDF.
- The PlanSFunder table did not get initialized with data.

# Expected Behavior After Changes

- PDF splitting on works with multiple PDFs do not lose relationships for child works split from first PDF.
- A database migration initializes the PlanSFunder table from the initial CSV and indexes all appropriate works.

# Screenshots / Video

<details>
<summary></summary>

### Child works and filesets have `is_page_of_ssim` indexed
![Screenshot 2023-05-17 at 10 58 37 AM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/c2221eaa-0c4d-4011-a69f-85bfaa93f004)

### First PDF begins with page 1 on the work's show page
![Screenshot 2023-05-15 at 8 09 41 PM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/29456a09-7a0e-4cc0-ad2f-5ca4bfc4fe90)
</details>

# Notes