### PR TITLE
🎁 Remove child works from faceted search

### DIFF
--- a/app/iiif_print/metadata_decorator.rb
+++ b/app/iiif_print/metadata_decorator.rb
@@ -9,7 +9,6 @@ module IiifPrint
           path = Rails.application.routes.url_helpers.search_catalog_path(
             "f[#{search_field}][]": value, locale: I18n.locale
           )
-          path += '&include_child_works=true' if work["is_child_bsi"] == true
           "<a href='#{File.join(@base_url, path)}'>#{value}</a>"
         end
       end


### PR DESCRIPTION
Prior to this commit, when clicking on the facets in the UV metadata pane under 'Page' the faceted search results contained the child works.

With this commit, the faceted search results do not contain any child works.

Ref #432

# Screenshots / Video
i432 Child Works in Facets.mp4
