### PR TITLE
🎁 Remove `wholeImageLowResAsJpg` download option

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,6 +1,9 @@
 {
   "modules": {
     "downloadDialogue": {
+      "options": {
+        "confinedImageSize": 1000000
+      },
       "content": {
         "wholeImageHighRes": "Whole image {0} x {1}px (jpg)"
       }


### PR DESCRIPTION
This commit is a bit of a workaround.  By setting the `confinedImageSize` to a very large number, we can effectively hide the `wholeImageLowResAsJpg` download option because of the way the.  This doesn't solve the root problem that the `EXTERNAL_IIIF_URL` is not being passed to the Universal Viewer correctly.  The "Current view" download option that appear when the image is zoomed in is still broken but it maybe not be as used or seen by users as the `wholeImageLowResAsJpg` download option.

- Todo: Figure out how to actually pass the `EXTERNAL_IIIF_URL` to the Universal Viewer.
- See: https://github.com/UniversalViewer/universalviewer/blob/v3.1.1/src/extensions/uv-seadragon-extension/DownloadDialogue.ts#L610-L616
- Resolves: https://github.com/scientist-softserv/britishlibrary/issues/429

# Screenshots / Video

<img width="279" alt="image" src="https://github.com/scientist-softserv/britishlibrary/assets/19597776/cb20b6e2-9b76-422a-88ce-084fca2bbd2f">
