### PR TITLE
🐛 Add rescue to ReindexFundersJob

### DIFF
--- a/app/jobs/reindex_funders_job.rb
+++ b/app/jobs/reindex_funders_job.rb
@@ -18,8 +18,14 @@ class ReindexFundersJob < ApplicationJob
 
           # reindex each work by id
           ids.each do |id|
-            ActiveFedora::Base.find(id)&.update_index
-            count_indexed += 1
+            begin
+              ActiveFedora::Base.find(id)&.update_index
+              count_indexed += 1
+            rescue => e
+              Rails.logger.info("😈😈😈 ERROR: unable to reindex id #{id} in tenant #{account.name}")
+              Rails.logger.info("#{e.message}")
+              next
+            end
           end
         end
       end

--- a/app/jobs/reindex_funders_job.rb
+++ b/app/jobs/reindex_funders_job.rb
@@ -22,8 +22,8 @@ class ReindexFundersJob < ApplicationJob
               ActiveFedora::Base.find(id)&.update_index
               count_indexed += 1
             rescue => e
-              Rails.logger.info("😈😈😈 ERROR: unable to reindex id #{id} in tenant #{account.name}")
-              Rails.logger.info("#{e.message}")
+              Rails.logger.error("😈😈😈 ERROR: unable to reindex id #{id} in tenant #{account.name}")
+              Rails.logger.error("#{e.message}")
               next
             end
           end

--- a/app/jobs/reindex_funders_job.rb
+++ b/app/jobs/reindex_funders_job.rb
@@ -21,9 +21,9 @@ class ReindexFundersJob < ApplicationJob
             begin
               ActiveFedora::Base.find(id)&.update_index
               count_indexed += 1
-            rescue => e
+            rescue StandardError => e
               Rails.logger.error("😈😈😈 ERROR: unable to reindex id #{id} in tenant #{account.name}")
-              Rails.logger.error("#{e.message}")
+              Rails.logger.error(e.message)
               next
             end
           end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -342,7 +342,7 @@
 
    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
    <!-- for suggestions -->
-   <copyField source="*_tesim" dest="suggest" maxChars="50000"/>
+   <copyField source="*_tesim" dest="suggest"/>
    <copyField source="*_ssim" dest="suggest"/>
 
  <!-- Similarity is the scoring routine for each document vs. a query.

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -342,7 +342,7 @@
 
    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
    <!-- for suggestions -->
-   <copyField source="*_tesim" dest="suggest"/>
+   <copyField source="*_tesim" dest="suggest" maxChars="50000"/>
    <copyField source="*_ssim" dest="suggest"/>
 
  <!-- Similarity is the scoring routine for each document vs. a query.


### PR DESCRIPTION
# Story
[This work](https://kew.iro.bl.uk/concern/articles/b551d066-a4f6-4543-87e6-2fe81d578ad0) gave an indexing error. When an indexing error occurs, the job will retry forever. 

In this case, the index for creator_search was indexing the full creator object for 266 creators, which resulted in too long of a string.

This PR attempts to handle the situation in two ways:
- increase the maxChars in the solr config xml
- add a rescue and log it to the rails logger if indexing fails, so the work is skipped but the rest of the works can continue to get reindexed. 

Refs [#440](https://github.com/scientist-softserv/britishlibrary/issues/440)

# Expected Behavior Before Changes
Job retries forever due to errors.

# Expected Behavior After Changes
The reindex funders job will complete normally.

# Screenshots / Video

<details>
<summary>Initial error</summary>

![Screenshot 2023-05-25 at 11 28 56 AM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/2d003672-807d-4dd3-97d8-10ac3eb02222)
</details>
<details>
<summary>Results after change</summary>

### Reindex job completes

Rails logging did not capture the expected log of error(s), which is apparently a known issue with Sidekiq. But the job did complete normally. 
![Screenshot 2023-05-25 at 3 03 54 PM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/f6082767-1d55-4828-8951-450eed7c933d)

### A record which got a solr error still does not reindex
![Screenshot 2023-05-25 at 3 21 02 PM](https://github.com/scientist-softserv/britishlibrary/assets/17851674/de053e6f-8450-45d3-b6a8-fbd3efe7a6c9)
</details>

# Notes
The Solr config change did not affect the ability to index the work with the issue. This work cannot be indexed upon save via the UI. This has been reported as a [separate bug](https://github.com/scientist-softserv/britishlibrary/issues/442).