### PR TITLE
put hyrax-app/tmp/shared on volume for when there are two or more wor…

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -37,6 +37,9 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/tmp/network_files
     subPath: network-files
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/shared
+    subPath: shared
 
 ingress:
   enabled: true

--- a/ops/review-deploy.tmpl.yaml
+++ b/ops/review-deploy.tmpl.yaml
@@ -36,6 +36,9 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/tmp/network_files
     subPath: network-files
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/shared
+    subPath: shared
 
 ingress:
   enabled: true


### PR DESCRIPTION
…kers

# Story

Noticed a number of errors during IiifPrint CreateDerivativesJob in which a tempfile was not being found in `/app/samverahyrax-app/tmp/shared`

https://scientist-inc.sentry.io/issues/3941591408/?project=6745017&query=is%3Aunresolved&referrer=issue-stream&stream_index=7

Noticed that we have two workers in production and that the staging deploy template has that directory as a volume, but production does not :/

# Expected Behavior Before Changes

Appearance of `unable to open image '/app/samvera/hyrax-webapp/tmp/shared/mini_magick20230608-1-12xume7.jpg': No such file or directory @ error/blob.c/OpenBlob/3570` type errors when there are two worker replicas in play

# Expected Behavior After Changes

Disappearance of `unable to open image '/app/samvera/hyrax-webapp/tmp/shared/mini_magick20230608-1-12xume7.jpg': No such file or directory @ error/blob.c/OpenBlob/3570` type errors when there are two worker replicas in play
