### PR TITLE
override can_create_any_work? to stop causing overlong solr queries

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -67,4 +67,28 @@ class Ability
   def can_export_works?
     can_create_any_work?
   end
+
+  # Overrides hyarx 2.9.6 to call a version of admin_set_with_deposit? that limits
+  # the id string used in the solr query to 200 ids (see admin_set_with_deposit_limited?
+  def can_create_any_work?
+    Hyrax.config.curation_concerns.any? do |curation_concern_type|
+      can?(:create, curation_concern_type)
+    end && admin_set_with_deposit_limited?
+  end
+
+  # If the ids string is too long then solr will bail so (until we are on hyrax3.x)
+  # introduce an _entirely_ abitrary limit to the number of ids used in query
+  # admin_Sets with depositos _should_ appear in the first 200 collections, but there
+  # is a risk that this fix will mis-report whether a user can create a work in an admin set
+  # The mis-report will be a false negative so will not admit users to any admin_sets
+  # they shouldn't have access to, but may in extreme circumstances lock some out.
+  # TODO upgrade hyrax used by hyku to version 3.x
+  def admin_set_with_deposit_limited?
+    ids = Hyrax::PermissionTemplateAccess.for_user(ability: self,
+                                                   access: ['deposit', 'manage'])
+                                         .joins(:permission_template)
+                                         .pluck(Arel.sql('DISTINCT source_id'))
+    query = "_query_:\"{!raw f=has_model_ssim}AdminSet\" AND {!terms f=id}#{ids.take(200).join(',')}"
+    ActiveFedora::SolrService.count(query).positive?
+  end
 end


### PR DESCRIPTION
# Story

Solr error for dashboard when too many collections

Refs #473

# Expected Behaviour Before Changes

Dashboard for bl-demo,iro.bl.uk (311 collections) throws error

# Expected Behaviour After Changes

Dashboard for bl-demo,iro.bl.uk (311 collections) does not throw error

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes