### PR TITLE
Save monoymous contributors and editors

### DIFF
--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -27,14 +27,12 @@ module Ubiquity
     #    c. Save the the array of hashes from step 2b
     #
     def save_creator
-      STDERR.puts "############# saving creator"
       self.creator_group ||= JSON.parse(self.creator.first) if self.creator.present?
       # remove Hash with empty values and nil
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.creator_group)
       # Check if the hash keys are only those used for default values like position
       data = compare_hash_keys?(clean_submitted_data)
-      STDERR.puts "############# #{data}"
-      STDERR.puts "############# #{clean_submitted_data}"
+
       if (self.creator_group.present? && clean_submitted_data.present? && data == false)
         creator_json = clean_submitted_data.to_json
         populate_creator_search_field(creator_json) unless self.instance_of?(Collection)
@@ -47,13 +45,11 @@ module Ubiquity
     end
 
     def save_contributor
-      STDERR.puts "############# saving contributor"
       self.contributor_group ||= JSON.parse(self.contributor.first) if self.contributor.present?
       clean_incomplete_data(self.contributor_group) if self.contributor.present?
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.contributor_group)
       data = compare_hash_keys?(clean_submitted_data)
-      STDERR.puts "############# #{data}"
-      STDERR.puts "############# #{clean_submitted_data}"
+
       if (self.contributor_group.present? && clean_submitted_data.present? && data == false )
         contributor_json = clean_submitted_data.to_json
         self.contributor = [contributor_json]

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -27,12 +27,14 @@ module Ubiquity
     #    c. Save the the array of hashes from step 2b
     #
     def save_creator
+      STDERR.puts "############# saving creator"
       self.creator_group ||= JSON.parse(self.creator.first) if self.creator.present?
       # remove Hash with empty values and nil
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.creator_group)
       # Check if the hash keys are only those used for default values like position
       data = compare_hash_keys?(clean_submitted_data)
-
+      STDERR.puts "############# #{data}"
+      STDERR.puts "############# #{clean_submitted_data}"
       if (self.creator_group.present? && clean_submitted_data.present? && data == false)
         creator_json = clean_submitted_data.to_json
         populate_creator_search_field(creator_json) unless self.instance_of?(Collection)
@@ -45,11 +47,13 @@ module Ubiquity
     end
 
     def save_contributor
+      STDERR.puts "############# saving contributor"
       self.contributor_group ||= JSON.parse(self.contributor.first) if self.contributor.present?
       clean_incomplete_data(self.contributor_group) if self.contributor.present?
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.contributor_group)
       data = compare_hash_keys?(clean_submitted_data)
-
+      STDERR.puts "############# #{data}"
+      STDERR.puts "############# #{clean_submitted_data}"
       if (self.contributor_group.present? && clean_submitted_data.present? && data == false )
         contributor_json = clean_submitted_data.to_json
         self.contributor = [contributor_json]
@@ -150,7 +154,7 @@ module Ubiquity
       return if data_hash.empty?
       field_name = get_field_name(data_hash)
       data_hash.each do |hash|
-        if (hash["#{field_name}_family_name"].blank? && hash["#{field_name}_organization_name"].blank?)
+        if (hash["#{field_name}_given_name"].blank? && hash["#{field_name}_organization_name"].blank?)
           hash.transform_values! { |v| nil }
         end
       end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -41,7 +41,7 @@
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right footer-link">
-        Managed by the <a href="https://www.bl.uk/">British Library</a>
+         Managed by the <a href="https://www.bl.uk/">British Library</a> and supported by the <a href="https://www.ukri.org/councils/ahrc/">AHRC</a>
         <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> & <a href="https://cosector.com/">CoSector</a>
       </div>
     </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -42,7 +42,7 @@
     <div class="navbar-right">
       <div class="navbar-text text-right footer-link">
          Managed by the <a href="https://www.bl.uk/">British Library</a> and supported by the <a href="https://www.ukri.org/councils/ahrc/">AHRC</a>
-        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> & <a href="https://cosector.com/">CoSector</a>
+        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> &amp; <a href="https://cosector.com/">CoSector</a>
       </div>
     </div>
   </div>

--- a/app/views/themes/bl_shared_home/shared/_footer.html.erb
+++ b/app/views/themes/bl_shared_home/shared/_footer.html.erb
@@ -22,8 +22,8 @@
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right footer-link">
-        Managed by the <a href="https://www.bl.uk/">British Library</a>
-        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> & <a href="https://cosector.com/">CoSector</a>
+        Managed by the <a href="https://www.bl.uk/">British Library</a> and supported by the <a href="https://www.ukri.org/councils/ahrc/">AHRC</a>
+        <br/>Provided by <a href="https://softserv.scientist.com/">Software Services by Scientist.com</a> &amp; <a href="https://cosector.com/">CoSector</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Story

Refs #386 # 471

An old ubiquity function `clean_incomplete-data` being called by `save_editor` and `save_contributor` but not `save_creator`
Have left this in place but changed so that `incomplete == no given name` rather than no family name. This brings the behaviour into line with the instructions on the form

# Expected Behavior Before Changes

Mononymous contributors and editors not saved

no mention of AHRC in footer

# Expected Behavior After Changes

Mononymous contributors and editors saved saved

AHRC in footer

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes