### PR TITLE
parse incoming slashy dates using the correct date format (╯°□°)╯ ┻━┻

### DIFF
--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -47,7 +47,7 @@ module Ubiquity
         case date
         when /^\d{4}-\d{2}$/ then Date.strptime(date, '%Y-%m') # 'YYYY-MM' format
         when %r{^\d{1,2}\/\d{4}$} then Date.strptime(date, '%m/%Y') # 'MM/YYYY' format
-        when %r{^\d{1,2}\/\d{1,2}\/\d{4}$} then Date.strptime(date, '%m/%d/%Y') # 'MM/DD/YYYY' format
+        when %r{^\d{1,2}\/\d{1,2}\/\d{4}$} then Date.strptime(date, '%d/%m/%Y') # 'DD/MM/YYYY' format
         else
           begin
             Date.parse(date)

--- a/spec/presenters/hyku/work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/work_show_presenter_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe Hyku::WorkShowPresenter do
         end
       end
 
-      context "when date_accepted is in MM/DD/YYYY format" do
-        let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+      context "when date_accepted is in DD/MM/YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["13/12/2023"] } }
 
         it "returns the formatted date" do
-          expect(presenter.date_accepted).to eq(["12/13/2023"])
+          expect(presenter.date_accepted).to eq(["13/12/2023"])
         end
       end
 
@@ -178,8 +178,8 @@ RSpec.describe Hyku::WorkShowPresenter do
         end
       end
 
-      context "when date_accepted is in MM/DD/YYYY format" do
-        let(:document) { { "date_accepted_tesim" => ["12/13/2023"] } }
+      context "when date_accepted is in DD/MM/YYYY format" do
+        let(:document) { { "date_accepted_tesim" => ["13/12/2023"] } }
 
         it "returns the formatted date" do
           expect(presenter.date_accepted).to eq(["2023"])

--- a/spec/services/ubiquity/parse_date_spec.rb
+++ b/spec/services/ubiquity/parse_date_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Ubiquity::ParseDate do
       expect(described_class.return_date_part(date, 'day')).to eq('13')
     end
 
-    it 'handles MM/DD/YYYY format' do
-      date = '12/13/2023'
+    it 'handles DD/MM/YYYY format' do
+      date = '13/12/2023'
       expect(described_class.return_date_part(date, 'year')).to eq('2023')
       expect(described_class.return_date_part(date, 'month')).to eq('12')
       expect(described_class.return_date_part(date, 'day')).to eq('13')


### PR DESCRIPTION
# Story

Refs #464

# Expected Behaviour Before Changes

If someone imports a date such as 23/05/2014 the edit page for the resulting work throws an error because it is trying to parse mm/dd/yyyy

# Expected Behaviour After Changes

Dates such as 23/05/2014 no longer throw errors on work edit page.... next: the correct spelling of Behaviour in this template ;p

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes