### PR TITLE
Avoid too long solr uris

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,7 +62,7 @@ class CatalogController < ApplicationController
     #
     # Without this parameter, we can easily enter a situation where the Solr query is too long for a
     # GET request.  Switching to :post avoids that problem.
-    # config.http_method :post
+    config.http_method = :post
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,20 +68,7 @@ class Ability
     can_create_any_work?
   end
 
-  # Overrides hyarx 2.9.6 to call a version of admin_set_with_deposit? that limits
-  # the id string used in the solr query to 200 ids (see admin_set_with_deposit_limited?
-#  def can_create_any_work?
-#    Hyrax.config.curation_concerns.any? do |curation_concern_type|
-#      can?(:create, curation_concern_type)
-#    end && admin_set_with_deposit_limited?
-#  end
-
-  # If the ids string is too long then solr will bail so (until we are on hyrax3.x)
-  # introduce an _entirely_ abitrary limit to the number of ids used in query
-  # admin_Sets with depositos _should_ appear in the first 200 collections, but there
-  # is a risk that this fix will mis-report whether a user can create a work in an admin set
-  # The mis-report will be a false negative so will not admit users to any admin_sets
-  # they shouldn't have access to, but may in extreme circumstances lock some out.
+  # Override Hyrax 2.9.6 to use post with solr and avoid over long URI errors
   # TODO upgrade hyrax used by hyku to version 3.x
   def admin_set_with_deposit?
     ids = Hyrax::PermissionTemplateAccess.for_user(ability: self,

--- a/config/initializers/collections_permission_service_overrides.rb
+++ b/config/initializers/collections_permission_service_overrides.rb
@@ -1,0 +1,27 @@
+Hyrax::Collections::PermissionsService.class_eval do 
+
+  # Override Hyrax 2.9.6 to use a post request and avoid Long URI errors from Solr
+  def self.filter_source(source_type:, ids:)
+    return [] if ids.empty?
+    id_clause = "{!terms f=id}#{ids.join(',')}"
+    query = case source_type
+            when 'admin_set'
+              "_query_:\"{!raw f=has_model_ssim}AdminSet\""
+            when 'collection'
+              "_query_:\"{!raw f=has_model_ssim}Collection\""
+            end
+    query += " AND #{id_clause}"
+    query(query, fl: 'id', rows: ids.count).map { |hit| hit['id'] }
+  end
+  private_class_method :filter_source
+
+  # Query solr using POST so that the query doesn't get too large for a URI
+  def self.query(query, args = {})
+    args[:q] = query
+    args[:qt] = 'standard'
+    conn = ActiveFedora::SolrService.instance.conn
+    result = conn.post('select', data: args)
+    result.fetch('response').fetch('docs')
+  end
+
+end


### PR DESCRIPTION
# Story

Various situations arise when there are a lot of collections that belong to a user in which big long queries that include all of those collection ids cause solr to carp about URIs that are too long. By making post rather than get requests in a small collection of places these errors are avoided.

Refs #473

# Expected Behavior Before Changes

300+ collections cause dashboard and collection pages (when logged in) to fail

# Expected Behavior After Changes

Dashboard and collection pages load even if there are many many collections

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes

My understanding is that the pre-Valkyrisation in Hyrax 3.5 may help with this issue