### PR TITLE
Hotfix: add Science Museum to this authority and present in alphabetical order

### DIFF
--- a/app/helpers/ubiquity/preselect_institution_helper.rb
+++ b/app/helpers/ubiquity/preselect_institution_helper.rb
@@ -12,7 +12,7 @@ module Ubiquity
                             'British Museum' => ['britishmuseum', 'britishmuseum-demo'],
                             'Tate' => ['tate', 'tate-demo'],
                             'Royal Botanic Gardens, Kew' => ['kew', 'kew-demo'],
-                            'Science Museum' => ['sciencemuseumgroup', 'sciencemuseumgroup-demo'],
+                            'Science Museum Group' => ['sciencemuseumgroup', 'sciencemuseumgroup-demo'],
                             'National Trust' => ['nt', 'nt-demo'],
                             '' => ['nhs', 'nhs-demo']
                           }

--- a/app/helpers/ubiquity/preselect_institution_helper.rb
+++ b/app/helpers/ubiquity/preselect_institution_helper.rb
@@ -12,6 +12,8 @@ module Ubiquity
                             'British Museum' => ['britishmuseum', 'britishmuseum-demo'],
                             'Tate' => ['tate', 'tate-demo'],
                             'Royal Botanic Gardens, Kew' => ['kew', 'kew-demo'],
+                            'Science Museum' => ['sciencemuseumgroup', 'sciencemuseumgroup-demo'],
+                            'National Trust' => ['nt', 'nt-demo'],
                             '' => ['nhs', 'nhs-demo']
                           }
       institution_hash.select { |_key, values| values.include?(tenant_name) }.keys.first

--- a/config/authorities/institution.yml
+++ b/config/authorities/institution.yml
@@ -47,5 +47,5 @@ terms:
     term: Somerset NHS Foundation Trust
     active: false
   - id: Science Museum
-    term: Science Museum
+    term: Science Museum Group
     active: true

--- a/config/authorities/institution.yml
+++ b/config/authorities/institution.yml
@@ -46,6 +46,6 @@ terms:
   - id: Somerset NHS Foundation Trust
     term: Somerset NHS Foundation Trust
     active: false
-  - id: Science Museum
+  - id: Science Museum Group
     term: Science Museum Group
     active: true

--- a/config/authorities/institution.yml
+++ b/config/authorities/institution.yml
@@ -16,6 +16,9 @@ terms:
   - id: National Museums Scotland
     term: National Museums Scotland
     active: true
+  - id: National Trust
+    term: National Trust
+    active: true
   - id: Royal Botanic Gardens, Kew
     term: Royal Botanic Gardens, Kew
     active: true
@@ -43,6 +46,6 @@ terms:
   - id: Somerset NHS Foundation Trust
     term: Somerset NHS Foundation Trust
     active: false
-  - id: National Trust
-    term: National Trust
+  - id: Science Museum
+    term: Science Museum
     active: true


### PR DESCRIPTION
# Story

Refs #480 

Adds Science Museum to institutions authority file

# Expected Behaviour Before Changes

Science Museum not an option for Institution field at deposit

# Expected Behaviour After Changes

Science Museum is an option for Institution field at deposit

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes