### PR TITLE
block spyders even after a deploy

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -246,7 +246,7 @@ nginx:
   image:
     registry: registry.gitlab.com
     repository: notch8/scripts/bitnami-nginx
-    tag: 1.21.5-debian-10-r4
+    tag: 1.21.5-debian-10-r7
   serverBlock: |-
     upstream rails_app {
       server {{ .Values.global.hyraxName }};

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -233,7 +233,7 @@ nginx:
   image:
     registry: registry.gitlab.com
     repository: notch8/scripts/bitnami-nginx
-    tag: 1.21.5-debian-10-r4
+    tag: 1.21.5-debian-10-r7
   serverBlock: |-
     upstream rails_app {
       server {{ .Values.global.hyraxName }};


### PR DESCRIPTION
persist the blocking code we put in by bumping the version of the image we use.