### PR TITLE
comment out video derivative that makes webm

### DIFF
--- a/config/initializers/file_set_derivatives_overrides.rb
+++ b/config/initializers/file_set_derivatives_overrides.rb
@@ -51,8 +51,8 @@ Hyrax::FileSetDerivativesService.class_eval do
     Hydra::Derivatives::VideoDerivatives.create(filename,
                                                 outputs: [{ label: :thumbnail, format: 'jpg',
                                                             url: derivative_url('thumbnail') },
-                                                          { label: 'webm', format: 'webm',
-                                                            url: derivative_url('webm') },
+#                                                          { label: 'webm', format: 'webm',
+#                                                            url: derivative_url('webm') },
                                                           { label: 'mp4', format: 'mp4',
                                                             url: derivative_url('mp4') }])
   end


### PR DESCRIPTION
# Story

Refs #497 

# Expected Behaviour Before Changes

When uploading larger mp4 files there's an an awful lot of time spent transcoding them to webms... To the point where they are stuck busy on the worker for hours and gobble up all the available memory

these webms don't get used in the UV player...

# Expected Behaviour After Changes

After removing the webm derivative generation we will expect no webm derivativess, but uploads of larger mp4s should complete, there should be no other effects on video playback...

