### PR TITLE
double memory and cpu limit for worker

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -188,8 +188,8 @@ worker:
       memory: "1Gi"
       cpu: "250m"
     limits:
-      memory: "2Gi"
-      cpu: "1000m"
+      memory: "4Gi"
+      cpu: "2000m"
   extraVolumeMounts: *volMounts
   extraEnvVars: *envVars
   podSecurityContext:


### PR DESCRIPTION
# Story

Refs #497 

# Expected Behaviour Before Changes

jobs get oom killed, esp ffmpeg and iiif_print jobs for many paged PDFs

# Expected Behaviour After Changes

less oom killing

