### PR TITLE
add a space when when glueing default solr params to end of search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -69,7 +69,7 @@ class CatalogController < ApplicationController
       qt: "search",
       rows: 10,
       qf: IiifPrint.config.metadata_fields.keys.map { |attribute| "#{attribute}_tesim" }
-                   .join(' ') << "title_tesim description_tesim all_text_timv"
+                   .join(' ') << " title_tesim description_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.


### PR DESCRIPTION
# Story

Look up of collections never get results

Refs  #451

This is due to the catalog controller building a solr query search string that looks like this:

`...add_info_tesim collection_tesimtitle_tesim description_tesim all_text_timv`

So the title lookup is doomed to fail

# Expected Behavior Before Changes

autocomplete lookup a collection when adding a work will not find any results

# Expected Behavior After Changes

autocomplete lookup a collection when adding a work will find expected results

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes