### PR TITLE
An initializer that overrides Hyrax::My::FindWorksSearchBuilder that …

### DIFF
--- a/config/initializers/search_builders.rb
+++ b/config/initializers/search_builders.rb
@@ -1,0 +1,3 @@
+# Overrides Hyrax 2.9.6 
+# Allow users to add other's works as child works
+Hyrax::My::FindWorksSearchBuilder.default_processor_chain -= [:show_only_resources_deposited_by_current_user]


### PR DESCRIPTION
…removes the filter set in Hyrax::My::SearchBuilder for that My::FindWorks... class

# Story

BL do not need to prevent users adding the works of other depositoers of child works. So the thing that filters these works from the lookup/autocomplete can be reversed

Refs #542

# Expected Behaviour Before Changes

When adding a child work on the relations tab the search will only return works that that user has deposited.

# Expected Behaviour After Changes

When adding a child work on the relations tab the search will only any works that are not caught by the existing filters which rule out works that are that work or parents of that work.

