### PR TITLE
Add PDF page limit for IiifPring splitter, PdfPage as pdf_split_child…

### DIFF
--- a/app/models/book_contribution.rb
+++ b/app/models/book_contribution.rb
@@ -14,7 +14,7 @@ class BookContribution < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: PdfPage
   )
 
   self.indexer = BookContributionIndexer


### PR DESCRIPTION
…_model for BookContribution

# Story

Refs #541 

# Expected Behaviour Before Changes

Any PDF goes to through the IiifPrint process and when there are 100's of pages stuff begins to slow and break

# Expected Behaviour After Changes

A config item can be set that will cause IiifPrint to bail out if the PDF being uploaded has more pages that the limit

