### PR TITLE
add SMG and NT to irus config

### DIFF
--- a/config/irus_analytics_config.yml
+++ b/config/irus_analytics_config.yml
@@ -61,3 +61,7 @@ production:
     source_repository: nms.iro.bl.uk
   mola.iro.bl.uk:
     source_repository: mola.iro.bl.uk
+  nt.iro.bl.uk:
+    source_repository: nt.iro.bl.uk
+  sciencemuseumgroup.iro.bl.uk:
+    source_repository: sciencemuseumgroup.iro.bl.uk


### PR DESCRIPTION
# Story

Refs n/a

# Expected Behaviour Before Changes

IRUS not currently logging SMG and NT tenants

# Expected Behaviour After Changes

IRUS logs SMG and NT tenants
