### PR TITLE
bump to_bulkrax 8.0.0 (requires rails bulkrax:update_status_messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,9 @@ end
 
 # Bulkrax :: Upgrading passed this point might cause issues, for now we've made a
 #            branch off v5.3.1 that includes `DownloadCloudFileJob` work.
-gem 'bulkrax', git: 'https://github.com/samvera/bulkrax', branch: '5.3.1-british_library'
+#gem 'bulkrax', git: 'https://github.com/samvera/bulkrax', branch: '5.3.1-british_library'
+gem 'bulkrax', git: 'https://github.com/samvera/bulkrax', tag: 'v8.0.0'
+
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,18 +41,19 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax
-  revision: 8c37b0d062ad362075e1912e3192da681e19713a
-  branch: 5.3.1-british_library
+  revision: 97abce11dce209dc325acb0f87e81753ffd65317
+  tag: v8.0.0
   specs:
-    bulkrax (5.3.1)
-      bagit (~> 0.4)
+    bulkrax (8.0.0)
+      bagit (~> 0.4.6)
       coderay
-      dry-monads (~> 1.4.0)
+      denormalize_fields
       iso8601 (~> 0.9.0)
       kaminari
       language_list (~> 1.2, >= 1.2.1)
       libxml-ruby (~> 3.2.4)
       loofah (>= 2.2.3)
+      marcel
       oai (>= 0.4, < 2.x)
       rack (>= 2.0.6)
       rails (>= 5.1.6)
@@ -398,6 +399,8 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     declarative (0.0.20)
+    denormalize_fields (1.3.0)
+      activerecord (>= 4.1.14, < 8.0.0)
     deprecation (1.1.0)
       activesupport
     devise (4.8.0)

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 if ENV.fetch('HYKU_BULKRAX_ENABLED', false)
+  Bulkrax.object_factory = Bulkrax::ObjectFactory
+
   # rubocop:disable Metrics/BlockLength
   Bulkrax.setup do |config|
     # Add local parsers


### PR DESCRIPTION
# Story

Refs # n/a

# Expected Behaviour Before Changes

Bulkrax exporter page timesout when there are mane exporters (e.g. 321)

# Expected Behaviour After Changes

There seems to be a bunch of imrpvement relating to the pagination for this stuff in v7 but trying v8 as this _also_ has the https://github.com/samvera/bulkrax/pull/930 change that kirk made specifically for BL

NB needs to run rails bulkrax:update_status_messages

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes