### PR TITLE
Don't add slash to URIs with obvious file.extensions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
       # Disable this extra authentication in test mode
       return true if Rails.env.test?
       return true # any hint of basic auth will stop BL staff from accessing site so instead we open all the "private" demo sites
-      if (is_hidden || is_staging) && !is_api_or_pdf
+      if (is_hidden || is_staging) && !is_api_or_pdf # rubocop:disable Lint/UnreachableCode
         authenticate_or_request_with_http_basic do |username, password|
           username == ENV.fetch("HYKU_DEMO_USER", "bl_demo_user") && password == ENV.fetch("HYKU_DEMO_PASSWORD", "resu_omed_lb")
         end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -230,3 +230,34 @@ Hyrax::IiifAv.config.iiif_av_viewer = :universal_viewer
 
 require 'hydra/derivatives'
 Hydra::Derivatives::Processors::Video::Processor.config.video_bitrate = '1500k'
+
+# Monkey patch Bulkrax so controlled URI validation allows http://thing.com/a/file/with/an/extension.html 
+# not just http://thing.com/thing(|/)
+# Remove all the trailing slashes from authorities and remove from input if present rather than the inverse
+module Bulkrax
+  # Import Behavior for Entry classes
+  module ImportBehavior # rubocop:disable Metrics/ModuleLength
+    #extend ActiveSupport::Concern
+
+    # @param value [String] value to validate
+    # @param field [String] name of the controlled property
+    # @return [String, nil] validated URI value or nil
+    def validate_value(value, field)
+      if value.match?(::URI::DEFAULT_PARSER.make_regexp)
+        value = value.strip.chomp
+        # add trailing forward slash unless one is already present or there's an obvious file extension
+        value << '/' unless value.match?(%r{/$}) || value.match?(%r{/[^./]+\.[^./]+$})
+      end
+
+      valid = if active_id_for_authority?(value, field)
+                true
+              else
+                value.include?('https') ? value.sub!('https', 'http') : value.sub!('http', 'https')
+                active_id_for_authority?(value, field)
+              end
+
+      valid ? value : nil
+    end
+
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -234,30 +234,25 @@ Hydra::Derivatives::Processors::Video::Processor.config.video_bitrate = '1500k'
 # Monkey patch Bulkrax so controlled URI validation allows http://thing.com/a/file/with/an/extension.html 
 # not just http://thing.com/thing(|/)
 # Remove all the trailing slashes from authorities and remove from input if present rather than the inverse
-module Bulkrax
-  # Import Behavior for Entry classes
-  module ImportBehavior # rubocop:disable Metrics/ModuleLength
-    #extend ActiveSupport::Concern
+Bulkrax::ImportBehavior.module_eval do 
 
-    # @param value [String] value to validate
-    # @param field [String] name of the controlled property
-    # @return [String, nil] validated URI value or nil
-    def validate_value(value, field)
-      if value.match?(::URI::DEFAULT_PARSER.make_regexp)
-        value = value.strip.chomp
-        # add trailing forward slash unless one is already present or there's an obvious file extension
-        value << '/' unless value.match?(%r{/$}) || value.match?(%r{/[^./]+\.[^./]+$})
-      end
-
-      valid = if active_id_for_authority?(value, field)
-                true
-              else
-                value.include?('https') ? value.sub!('https', 'http') : value.sub!('http', 'https')
-                active_id_for_authority?(value, field)
-              end
-
-      valid ? value : nil
+  # @param value [String] value to validate
+  # @param field [String] name of the controlled property
+  # @return [String, nil] validated URI value or nil
+  def validate_value(value, field)
+    if value.match?(::URI::DEFAULT_PARSER.make_regexp)
+      value = value.strip.chomp
+      # add trailing forward slash unless one is already present or there's an obvious file extension
+      value << '/' unless value.match?(%r{/$}) || value.match?(%r{/[^./]+\.[^./]+$})
     end
 
+    valid = if active_id_for_authority?(value, field)
+              true
+            else
+              value.include?('https') ? value.sub!('https', 'http') : value.sub!('http', 'https')
+              active_id_for_authority?(value, field)
+            end
+
+    valid ? value : nil
   end
 end


### PR DESCRIPTION
# Story

Refs https://notch8.slack.com/archives/C087NA91RQT/p1762414869965019

# Expected Behavior Before Changes

If a license chosen did not end with a slash in the authority file then it would not be found

e.g. "http://www.europeana.eu/portal/rights/rr-r.html" was getting a slash added and then not matching the term in the authority file... 

# Expected Behavior After Changes

http://www.europeana.eu/portal/rights/rr-r.html is still a valid URI so URIs that are obviously ending with `file.extenstion` don't get slash added

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes