### PR TITLE
reinstate basic_auth crawl protection for demo sites :|

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
       # Disable this extra authentication in test mode
       return true if Rails.env.test?
       #return true # any hint of basic auth will stop BL staff from accessing site so instead we open all the "private" demo sites
-      if (is_hidden || is_staging) && !is_api_or_pdf # rubocop:disable Lint/UnreachableCode
+      if (is_hidden || is_staging) && !is_api_or_pdf 
         authenticate_or_request_with_http_basic do |username, password|
           username == ENV.fetch("HYKU_DEMO_USER", "bl_demo_user") && password == ENV.fetch("HYKU_DEMO_PASSWORD", "resu_omed_lb")
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
     def authenticate_if_needed
       # Disable this extra authentication in test mode
       return true if Rails.env.test?
-      return true # any hint of basic auth will stop BL staff from accessing site so instead we open all the "private" demo sites
+      #return true # any hint of basic auth will stop BL staff from accessing site so instead we open all the "private" demo sites
       if (is_hidden || is_staging) && !is_api_or_pdf # rubocop:disable Lint/UnreachableCode
         authenticate_or_request_with_http_basic do |username, password|
           username == ENV.fetch("HYKU_DEMO_USER", "bl_demo_user") && password == ENV.fetch("HYKU_DEMO_PASSWORD", "resu_omed_lb")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
       # Disable this extra authentication in test mode
       return true if Rails.env.test?
       #return true # any hint of basic auth will stop BL staff from accessing site so instead we open all the "private" demo sites
-      if (is_hidden || is_staging) && !is_api_or_pdf 
+      if (is_hidden || is_staging) && !is_api_or_pdf
         authenticate_or_request_with_http_basic do |username, password|
           username == ENV.fetch("HYKU_DEMO_USER", "bl_demo_user") && password == ENV.fetch("HYKU_DEMO_PASSWORD", "resu_omed_lb")
         end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,7 @@ services:
     ## interact with the breakpoints.
     ##
     # command: sh -l -c "bundle && tail -f /dev/null"
+    command: tail -f /dev/null
     depends_on:
       db:
         condition: service_started


### PR DESCRIPTION
# Story

reverts pull/618 because crawlers are crawling demo sites

